### PR TITLE
Made coyote time the whole sprite to fix player/wall collision

### DIFF
--- a/src/entities/entity.c
+++ b/src/entities/entity.c
@@ -133,9 +133,9 @@ Entity *GetGroundBeneath(Entity *entity) {
 
             // TODO increase x tolerance
 
-            // If x is within the possible ground, with a fraction of the player's hitbox as "coyote time"
-            possibleGround->hitbox.x < (entity->hitbox.x + ((4*entity->hitbox.width)/5)) &&
-            entity->hitbox.x + (entity->hitbox.width/5) < (possibleGround->hitbox.x + possibleGround->hitbox.width) &&
+            // If x is within the possible ground
+            possibleGround->hitbox.x < (entity->hitbox.x + entity->hitbox.width) &&
+            entity->hitbox.x < (possibleGround->hitbox.x + possibleGround->hitbox.width) &&
 
             // If y is RIGHT above the possible ground
             abs(possibleGround->hitbox.y - entitysFoot) <= ON_THE_GROUND_Y_TOLERANCE) {


### PR DESCRIPTION
The current implementation of coyote time would have the player start falling off a platform while its hitbox's width was still within the ground's width. This was breaking the player/wall collision. To fix it I set the coyote time to be the whole hitbox. This system will have to be revisited in the future anyways, so it's better to simplify its implementation while solving a bug.