### PR TITLE
Destroy Overworld Entity function

### DIFF
--- a/src/overworld.c
+++ b/src/overworld.c
@@ -42,6 +42,16 @@ static void updateCursorPosition() {
                     cursorDimensions.height;
 }
 
+static void destroyEntityOverworld(ListNode *node) {
+
+    OverworldEntity *entity = (OverworldEntity *) node->item;
+    MemFree(entity->levelName);
+
+    LinkedListRemove(&OW_LIST_HEAD, node);
+
+    TraceLog(LOG_TRACE, "Destroyed overworld entity.");
+}
+
 static void initializeCursor() {
 
     OverworldEntity *newCursor = MemAlloc(sizeof(OverworldEntity));
@@ -69,6 +79,7 @@ static OverworldEntity *addTileToOverworld(Vector2 pos, OverworldTileType type, 
 
     newTile->tileType = type;
     newTile->gridPos = pos;
+    newTile->levelName = MemAlloc(sizeof(char) * LEVEL_NAME_BUFFER_SIZE);
 
     switch (newTile->tileType)
     {
@@ -192,6 +203,11 @@ void OverworldLevelSelect() {
 
     if (!(STATE->tileUnderCursor->components & OW_IS_LEVEL_DOT)) {
         TraceLog(LOG_TRACE, "Overworld tried to enter level, but not a dot.");
+        return;
+    }
+
+    if (!STATE->tileUnderCursor->levelName) {
+        TraceLog(LOG_ERROR, "tileUnderCursor has no levelName reference.");
         return;
     }
 
@@ -362,8 +378,8 @@ void OverworldTileRemoveAt(Vector2 pos) {
         return;
     }
 
-    LinkedListRemove(&OW_LIST_HEAD, node);
-    TraceLog(LOG_TRACE, "Removed overworld tile.");
+    
+    destroyEntityOverworld(node);
 }
 
 void OverworldTick() {

--- a/src/overworld.h
+++ b/src/overworld.h
@@ -40,7 +40,7 @@ typedef struct OverworldEntity {
     Sprite sprite;
     int layer;
     
-    char levelName[LEVEL_NAME_BUFFER_SIZE];
+    char *levelName;
 
 } OverworldEntity;
 

--- a/src/render.c
+++ b/src/render.c
@@ -262,9 +262,16 @@ skip_debug_grid:
 
             Vector2 pos = PosInSceneToScreen((Vector2){ tile->gridPos.x - 20,
                                 tile->gridPos.y + (tile->sprite.sprite.height * tile->sprite.scale) });
+
             char levelName[LEVEL_NAME_BUFFER_SIZE];
+
+            if (!tile->levelName)
+                TraceLog(LOG_ERROR, "Overworld level dot to be rendered has no levelName referenced.");
+
             if (tile->levelName[0] != '\0') strcpy(levelName, tile->levelName);
+
             else strcpy(levelName, "[sem fase]");
+
             DrawText(levelName, pos.x, pos.y, 20, RAYWHITE);
         }
 


### PR DESCRIPTION
Created a destroyEntityOverworld() that frees the levelName memory from an Overworld Entity.

Also turned the levelName field into a pointer.

This introduces destructors to the project, something every list item should have.