### PR TITLE
Player-block collision reverts player movement

### DIFF
--- a/src/linked_list.c
+++ b/src/linked_list.c
@@ -46,6 +46,17 @@ void LinkedListRemove(ListNode **head, ListNode *node) {
     TraceLog(LOG_TRACE, "Removed item from linked list and destroyed it.");
 }
 
+ListNode *LinkedListGetNode(ListNode *head, void *item) {
+
+    while (head != 0 && head->item != item) {
+        head = head->next;
+    }
+
+    TraceLog(LOG_TRACE, "Linked list get node returning %x.", head);
+
+    return head;
+}
+
 void LinkedListRemoveAll(ListNode **head) {
 
     while (*head) {

--- a/src/linked_list.h
+++ b/src/linked_list.h
@@ -13,6 +13,9 @@ typedef struct ListNode {
 // Adds new node containing 'item' to a linked list. Returns the new node.
 ListNode *LinkedListAdd(ListNode **head, void *item);
 
+// Returns list node containing item, or 0 if not found.
+ListNode *LinkedListGetNode(ListNode *head, void *item);
+
 // Removes and destroys node from a linked list.
 void LinkedListRemove(ListNode **head, ListNode *node);
 


### PR DESCRIPTION
When the player collides with a block, its X & Y positions and restored to the values before the current tick, preventing him from going through the walls in certain cases.

When reordering the events in the player's tick, a bug was introduced: When leaping off an enemy the player would stop colliding with it before having the chance to register its death. So a second "player hit enemy" check was added inside the "starts jumping" conditional.