### PR TITLE
Level Entity origin

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -17,9 +17,8 @@ static size_t mouseEnabledReferences = 0;
 void GameStateInitialize() {
     STATE = MemAlloc(sizeof(GameState));
 
-    // Debug
+    STATE->showBackground = true;
     STATE->showDebugHUD = false;
-    STATE->showBackground = false;
 
     EditorDisable();
 

--- a/src/level/block.c
+++ b/src/level/block.c
@@ -4,16 +4,17 @@
 #include "../core.h"
 
 
-void LevelBlockAdd(Vector2 pos) {
+void LevelBlockAdd(Vector2 origin) {
 
     LevelEntity *newBlock = MemAlloc(sizeof(LevelEntity));
 
-    pos.x = SnapToGrid(pos.x, LEVEL_GRID.width);
-    pos.y = SnapToGrid(pos.y, LEVEL_GRID.height);
+    origin.x = SnapToGrid(origin.x, LEVEL_GRID.width);
+    origin.y = SnapToGrid(origin.y, LEVEL_GRID.height);
 
     newBlock->components = LEVEL_IS_SCENARIO +
                             LEVEL_IS_GROUND;
-    newBlock->hitbox = SpriteHitboxFromEdge(BlockSprite, pos);
+    newBlock->origin = origin;
+    newBlock->hitbox = SpriteHitboxFromEdge(BlockSprite, origin);
     newBlock->sprite = BlockSprite;
 
     LinkedListAdd(&LEVEL_LIST_HEAD, newBlock);
@@ -22,7 +23,7 @@ void LevelBlockAdd(Vector2 pos) {
                 newBlock->hitbox.x, newBlock->hitbox.y);
 }
 
-void LevelBlockCheckAndAdd(Vector2 pos) {
+void LevelBlockCheckAndAdd(Vector2 origin) {
 
     ListNode *node = LEVEL_LIST_HEAD;
 
@@ -31,7 +32,7 @@ void LevelBlockCheckAndAdd(Vector2 pos) {
         LevelEntity *possibleBlock = (LevelEntity *)node->item;
 
         if (possibleBlock->components & LEVEL_IS_SCENARIO &&
-                CheckCollisionPointRec(pos, possibleBlock->hitbox)) {
+                CheckCollisionPointRec(origin, possibleBlock->hitbox)) {
 
             return;
         }
@@ -39,5 +40,5 @@ void LevelBlockCheckAndAdd(Vector2 pos) {
         node = node->next;
     }
 
-    LevelBlockAdd(pos);
+    LevelBlockAdd(origin);
 }

--- a/src/level/enemy.c
+++ b/src/level/enemy.c
@@ -8,13 +8,14 @@
 #define ENEMY_FALL_RATE 7.0f
 
 
-void LevelEnemyAdd(Vector2 pos) {
+void LevelEnemyAdd(Vector2 origin) {
 
     LevelEntity *newEnemy = MemAlloc(sizeof(LevelEntity));
 
     newEnemy->components = LEVEL_IS_ENEMY +
                             LEVEL_IS_GROUND;
-    newEnemy->hitbox = SpriteHitboxFromEdge(EnemySprite, pos);
+    newEnemy->origin = origin;
+    newEnemy->hitbox = SpriteHitboxFromEdge(EnemySprite, origin);
     newEnemy->sprite = EnemySprite;
     newEnemy->isFacingRight = true;
     newEnemy->isFallingDown = true;
@@ -25,9 +26,9 @@ void LevelEnemyAdd(Vector2 pos) {
                 newEnemy->hitbox.x, newEnemy->hitbox.y);
 }
 
-void LevelEnemyCheckAndAdd(Vector2 pos) {    
+void LevelEnemyCheckAndAdd(Vector2 origin) {    
 
-    Rectangle hitbox = SpriteHitboxFromMiddle(EnemySprite, pos);
+    Rectangle hitbox = SpriteHitboxFromMiddle(EnemySprite, origin);
 
     ListNode *node = LEVEL_LIST_HEAD;
 

--- a/src/level/level.c
+++ b/src/level/level.c
@@ -15,6 +15,12 @@
 // THe name of a new level
 #define DEFAULT_NEW_LEVEL_NAME "new_level.lvl"
 
+// The players origin for all new levels, unchangeably.
+// -- This allows us to set the player's origin via code for all new levels,
+// untying it from the default new level's data.
+// TODO allow to drag and modify the player's origin in the editor
+#define PLAYERS_ORIGIN (Vector2){ 344, 200 };
+
 
 ListNode *LEVEL_LIST_HEAD = 0;
 
@@ -256,5 +262,10 @@ void LevelSave() {
 
 void LevelLoadNew() {
     LevelInitialize(NEW_LEVEL_NAME);
+
+    LEVEL_PLAYER->origin = PLAYERS_ORIGIN;
+    LEVEL_PLAYER->hitbox.x = LEVEL_PLAYER->origin.x;
+    LEVEL_PLAYER->hitbox.y = LEVEL_PLAYER->origin.y;
+
     strcpy(STATE->loadedLevel, DEFAULT_NEW_LEVEL_NAME);
 }

--- a/src/level/level.c
+++ b/src/level/level.c
@@ -111,6 +111,7 @@ void LevelExitAdd(Vector2 pos) {
 
     newExit->components = LEVEL_IS_EXIT;
     newExit->hitbox = hitbox;
+    newExit->origin = pos;
     newExit->sprite = sprite;
     newExit->isFacingRight = true;
 

--- a/src/level/level.c
+++ b/src/level/level.c
@@ -20,8 +20,6 @@ ListNode *LEVEL_LIST_HEAD = 0;
 
 double levelConcludedAgo = -1;
 
-static Vector2 playersStartingPosition =  { SCREEN_WIDTH/5, 300 };
-
 static ListNode *levelExitNode = 0;
 
 
@@ -143,10 +141,6 @@ void LevelExitCheckAndAdd(Vector2 pos) {
     LevelExitAdd((Vector2){ hitbox.x, hitbox.y });
 }
 
-Vector2 LevelGetPlayerStartingPosition() {
-    return playersStartingPosition;
-}
-
 LevelEntity *LevelGetGroundBeneath(LevelEntity *entity) {
 
     int entitysFoot = entity->hitbox.y + entity->hitbox.height;
@@ -263,8 +257,4 @@ void LevelSave() {
 void LevelLoadNew() {
     LevelInitialize(NEW_LEVEL_NAME);
     strcpy(STATE->loadedLevel, DEFAULT_NEW_LEVEL_NAME);
-}
-
-void LevelPlayerSetStartingPos(Vector2 pos) {
-    playersStartingPosition = pos;
 }

--- a/src/level/level.c
+++ b/src/level/level.c
@@ -31,7 +31,7 @@ static ListNode *levelExitNode = 0;
 
 // Searches for an entity in a given position
 // and returns its node, or 0 if not found.
-static ListNode *getNodeOfEntityOn(Vector2 pos) {
+static ListNode *getEntityOnScene(Vector2 pos) {
 
     ListNode *node = LEVEL_LIST_HEAD;
 
@@ -205,7 +205,7 @@ void LevelEntityDestroy(ListNode *node) {
 
 LevelEntity *LevelEntityGetAt(Vector2 pos) {
 
-    ListNode *node = getNodeOfEntityOn(pos);
+    ListNode *node = getEntityOnScene(pos);
 
     if (!node) return 0;
 
@@ -214,11 +214,29 @@ LevelEntity *LevelEntityGetAt(Vector2 pos) {
 
 void LevelEntityRemoveAt(Vector2 pos) {
 
-    ListNode *node = getNodeOfEntityOn(pos);
-    if (!node) return;
+    ListNode *node = LEVEL_LIST_HEAD;
+    while (node != 0) {
 
-    LevelEntity *entity = (LevelEntity *) node->item;
-    if (entity->components & LEVEL_IS_PLAYER) return;
+        LevelEntity *entity = (LevelEntity *) node->item;
+
+        if (entity->components & LEVEL_IS_PLAYER) goto next_node;
+
+        if (CheckCollisionPointRec(pos, (Rectangle) {
+                                                entity->origin.x,       entity->origin.y,
+                                                entity->hitbox.width,   entity->hitbox.height
+                                            })) {
+            break;
+        }
+
+        if (CheckCollisionPointRec(pos, entity->hitbox)) {
+            break;
+        }
+
+next_node:
+        node = node->next;
+    };
+
+    if (!node) return;
 
     LevelEntityDestroy(node);
 }

--- a/src/level/level.h
+++ b/src/level/level.h
@@ -24,6 +24,7 @@ typedef enum LevelEntityComponent {
 typedef struct LevelEntity {
 
     unsigned long int components;
+    Vector2 origin;
     Rectangle hitbox;
 
     Sprite sprite;
@@ -87,9 +88,6 @@ void LevelExitAdd(Vector2 pos);
 
 void LevelExitCheckAndAdd(Vector2 pos);
 
-// Returns the player's starting position for the currently loaded level
-Vector2 LevelGetPlayerStartingPosition();
-
 // The ground beneath the entity, or 0 if not on the ground.
 // Gives priority to the tile in the direction the player is looking at.
 LevelEntity *LevelGetGroundBeneath(LevelEntity *entity);
@@ -112,7 +110,7 @@ void LevelSave();
 void LevelLoadNew();
 
 
-void LevelPlayerInitialize(Vector2 pos);
+void LevelPlayerInitialize(Vector2 origin);
 
 void LevelPlayerMoveHorizontal(PlayerHorizontalMovementType direction);
 
@@ -127,25 +125,22 @@ void LevelPlayerTick();
 // Continues the game after dying.
 void LevelPlayerContinue();
 
-// TODO remove it and use entity origin instead
-void LevelPlayerSetStartingPos(Vector2 pos);
 
+// Initializes and adds an enemy to the level in the given origin
+void LevelEnemyAdd(Vector2 origin);
 
-// Initializes and adds an enemy to the level in the given pos
-void LevelEnemyAdd(Vector2 pos);
-
-// Initializes and adds an enemy to the level in the given pos,
+// Initializes and adds an enemy to the level in the given origin,
 // if there are not other elements there already.
-void LevelEnemyCheckAndAdd(Vector2 pos);
+void LevelEnemyCheckAndAdd(Vector2 origin);
 
 void LevelEnemyTick(ListNode *enemyNode);
 
 
-void LevelBlockAdd(Vector2 pos);
+void LevelBlockAdd(Vector2 origin);
 
-// Initializes and adds a block to the level in the given pos,
+// Initializes and adds a block to the level in the given origin,
 // if there are no other blocks there already.
-void LevelBlockCheckAndAdd(Vector2 pos);
+void LevelBlockCheckAndAdd(Vector2 origin);
 
 
 #endif // _LEVEL_H_INCLUDED_

--- a/src/level/player.c
+++ b/src/level/player.c
@@ -27,7 +27,7 @@
 
 // How many seconds before landing on the ground the jump command
 // still works 
-#define JUMP_BUFFER_BACKWARDS_SIZE      0.06f         
+#define JUMP_BUFFER_BACKWARDS_SIZE      0.08f         
 
 // How many seconds after having left the ground the jump command
 // still works
@@ -103,22 +103,21 @@ static void die() {
                 LEVEL_PLAYER->hitbox.x, LEVEL_PLAYER->hitbox.y, LEVEL_PLAYER_STATE->isJumping);
 }
 
-void LevelPlayerInitialize(Vector2 pos) {
+void LevelPlayerInitialize(Vector2 origin) {
 
     LevelEntity *newPlayer = MemAlloc(sizeof(LevelEntity));
     LEVEL_PLAYER = newPlayer;
     LinkedListAdd(&LEVEL_LIST_HEAD, newPlayer);
     
     newPlayer->components = LEVEL_IS_PLAYER;
-    newPlayer->hitbox = SpriteHitboxFromEdge(PlayerSprite, pos);
+    newPlayer->origin = origin;
+    newPlayer->hitbox = SpriteHitboxFromEdge(PlayerSprite, origin);
     newPlayer->sprite = PlayerSprite;
     newPlayer->isFacingRight = true;
 
     resetPlayerState();
     
     syncPlayersHitboxes();
-
-    LevelPlayerSetStartingPos(pos); // TODO replace it with entity origin
 
     TraceLog(LOG_TRACE, "Added player to level (x=%.1f, y=%.1f)",
                 newPlayer->hitbox.x, newPlayer->hitbox.y);
@@ -335,9 +334,17 @@ void LevelPlayerContinue() {
     STATE->isPaused = false;
     resetPlayerState();
 
-    Vector2 pos = LevelGetPlayerStartingPosition();
-    LEVEL_PLAYER->hitbox.x = pos.x;
-    LEVEL_PLAYER->hitbox.y = pos.y;
+    // Reset all the alive entities to their origins
+    ListNode *node = LEVEL_LIST_HEAD;
+    while (node) {
+
+        LevelEntity *entity = (LevelEntity *) node->item;
+        entity->hitbox.x = entity->origin.x;
+        entity->hitbox.y = entity->origin.y;
+
+        node = node->next;
+    }
+
     syncPlayersHitboxes();
     CameraLevelCentralizeOnPlayer();
 

--- a/src/level/player.c
+++ b/src/level/player.c
@@ -31,7 +31,7 @@
 
 // How many seconds after having left the ground the jump command
 // still works
-#define JUMP_BUFFER_FORWARDS_SIZE       0.05f
+#define JUMP_BUFFER_FORWARDS_SIZE       0.06f
 
 
 LevelEntity *LEVEL_PLAYER = 0;

--- a/src/overworld.c
+++ b/src/overworld.c
@@ -112,7 +112,7 @@ static OverworldEntity *addTileToOverworld(Vector2 pos, OverworldTileType type, 
 
 // Searches for an entity that's not the cursor
 // in a given position and returns its node, or 0 if not found.
-static ListNode *getNodeOfEntityOn(Vector2 pos) {
+static ListNode *getEntityOnScene(Vector2 pos) {
 
     ListNode *node = OW_LIST_HEAD;
 
@@ -363,7 +363,7 @@ next_entity:
 
 void OverworldTileRemoveAt(Vector2 pos) {
 
-    ListNode *node = getNodeOfEntityOn(pos);
+    ListNode *node = getEntityOnScene(pos);
 
     if (!node) {
 

--- a/src/persistence.c
+++ b/src/persistence.c
@@ -27,8 +27,8 @@ typedef enum LevelEntityType {
 
 typedef struct PersistenceLevelEntity {
     uint16_t entityType;
-    uint32_t x;
-    uint32_t y;
+    uint32_t originX;
+    uint32_t originY;
 } PersistenceLevelEntity;
 
 
@@ -63,8 +63,8 @@ void PersistenceLevelSave(char *levelName) {
             goto skip_entity; 
         }
         
-        data[i].x = (uint32_t) entity->hitbox.x;
-        data[i].y = (uint32_t) entity->hitbox.y;
+        data[i].originX = (uint32_t) entity->origin.x;
+        data[i].originY = (uint32_t) entity->origin.y;
 
         i++;
 
@@ -108,21 +108,21 @@ bool PersistenceLevelLoad(char *levelName) {
 
     for (size_t i = 0; i < filedata.itemCount; i++) {
 
-        Vector2 pos = (Vector2){
-            (float) data[i].x,
-            (float) data[i].y    
+        Vector2 origin = (Vector2){
+            (float) data[i].originX,
+            (float) data[i].originY    
         };
 
         switch (data[i].entityType) {
         
         case LEVEL_ENTITY_PLAYER:
-            LevelPlayerInitialize(pos); break;
+            LevelPlayerInitialize(origin); break;
         case LEVEL_ENTITY_ENEMY:
-            LevelEnemyAdd(pos); break;
+            LevelEnemyAdd(origin); break;
         case LEVEL_ENTITY_BLOCK:
-            LevelBlockAdd(pos); break;
+            LevelBlockAdd(origin); break;
         case LEVEL_ENTITY_EXIT:
-            LevelExitAdd(pos); break;
+            LevelExitAdd(origin); break;
         default:
             TraceLog(LOG_ERROR, "Unknow entity type found when desserializing level, type=%d.", data[i].entityType); 
         }

--- a/src/render.c
+++ b/src/render.c
@@ -160,6 +160,17 @@ static void drawLevelEntity(LevelEntity *entity) {
     drawTexture(entity->sprite, (Vector2){ pos.x, pos.y }, WHITE, !entity->isFacingRight);
 }
 
+
+static void drawLevelEntityOrigin(LevelEntity *entity) {
+
+    Vector2 pos = PosInSceneToScreen((Vector2){
+                                        entity->origin.x,
+                                        entity->origin.y });
+
+    drawTexture(entity->sprite, (Vector2){ pos.x, pos.y },
+                (Color) { WHITE.r, WHITE.g, WHITE.b, 30 }, false);
+}
+
 static void drawEntities() {
 
     for (int layer = FIRST_LAYER; layer <= LAST_LAYER; layer++) {
@@ -171,7 +182,9 @@ static void drawEntities() {
             if (STATE->mode == MODE_IN_LEVEL) {
                 LevelEntity *entity = (LevelEntity *) node->item;
                 if (entity->layer != layer) goto next_entity;
+
                 drawLevelEntity(entity);
+                if (STATE->isEditorEnabled) drawLevelEntityOrigin(entity);
             }
 
             else if (STATE->mode == MODE_OVERWORLD) {


### PR DESCRIPTION
Adds the "origin" property to LevelEntity. This is the field saved to persistence, instead of the entity's current position. 

The origin are the coordinates used to initialize the all the level entities, and when resetting the level state, the entities positions are reset to the origin.

For clarity and usability, when the editor is enabled, the entity's sprite is rendered with some transparency to indicate the entity's origin. This sprite can be used to delete the entity using the eraser.