### PR TITLE
Editor and debug HUD improvements

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -7,6 +7,7 @@
 #include "level/level.h"
 #include "editor.h"
 #include "string.h"
+#include "render.h"
 
 
 GameState *STATE = 0;
@@ -102,8 +103,13 @@ void MouseCursorEnable() {
 
 void DebugHudToggle() {
 
-    if (STATE->showDebugHUD) DebugHudDisable();
-    else DebugHudEnable();
+    if (STATE->showDebugHUD) {
+        RenderDebugEntityStopAll();
+        DebugHudDisable();
+    }
+    else {
+        DebugHudEnable();
+    }
 }
 
 bool IsInPlayArea(Vector2 pos) {

--- a/src/editor.c
+++ b/src/editor.c
@@ -68,8 +68,8 @@ void loadOverworldEditor() {
 
 void EditorSync() {
 
-    LinkedListRemoveAll(&EDITOR_ENTITIES_HEAD);
-    LinkedListRemoveAll(&EDITOR_CONTROL_HEAD);
+    LinkedListDestroyAll(&EDITOR_ENTITIES_HEAD);
+    LinkedListDestroyAll(&EDITOR_CONTROL_HEAD);
 
     switch (STATE->mode) {
     
@@ -88,8 +88,8 @@ void EditorSync() {
 
 void EditorEmpty() {
 
-    LinkedListRemoveAll(&EDITOR_ENTITIES_HEAD);
-    LinkedListRemoveAll(&EDITOR_CONTROL_HEAD);
+    LinkedListDestroyAll(&EDITOR_ENTITIES_HEAD);
+    LinkedListDestroyAll(&EDITOR_CONTROL_HEAD);
 
     STATE->editorSelectedEntity = 0;
 

--- a/src/input.c
+++ b/src/input.c
@@ -88,7 +88,7 @@ void handleDevInput() {
 
     if (STATE->showDebugHUD) {
 
-        if      (IsMouseButtonPressed(MOUSE_BUTTON_LEFT))      RenderShowEntityInfo(
+        if      (IsMouseButtonPressed(MOUSE_BUTTON_LEFT))      RenderDebugEntityToggle(
                                                                     LevelEntityGetAt(mousePosInScene));
     }
 }

--- a/src/level/block.c
+++ b/src/level/block.c
@@ -25,20 +25,7 @@ void LevelBlockAdd(Vector2 origin) {
 
 void LevelBlockCheckAndAdd(Vector2 origin) {
 
-    ListNode *node = LEVEL_LIST_HEAD;
-
-    while (node != 0) {
-        
-        LevelEntity *possibleBlock = (LevelEntity *)node->item;
-
-        if (possibleBlock->components & LEVEL_IS_SCENARIO &&
-                CheckCollisionPointRec(origin, possibleBlock->hitbox)) {
-
-            return;
-        }
-
-        node = node->next;
-    }
-
+    Rectangle hitbox = SpriteHitboxFromMiddle(BlockSprite, origin);
+    if (LevelCheckCollisionWithAnythingElse(hitbox)) return;
     LevelBlockAdd(origin);
 }

--- a/src/level/enemy.c
+++ b/src/level/enemy.c
@@ -117,8 +117,7 @@ void LevelEnemyKill(LevelEntity *entity) {
 
     entity->isDead = true;
 
-    RenderShowEntityInfoStop(); // gambiarra
-
+    RenderDebugEntityStop(entity);
 
     TraceLog(LOG_TRACE, "Enemy died.");
 }

--- a/src/level/enemy.c
+++ b/src/level/enemy.c
@@ -31,32 +31,9 @@ void LevelEnemyCheckAndAdd(Vector2 origin) {
 
     Rectangle hitbox = SpriteHitboxFromMiddle(EnemySprite, origin);
 
-    ListNode *node = LEVEL_LIST_HEAD;
-
-    while (node != 0) {
-    
-        LevelEntity *entity = (LevelEntity *) node->item;
-
-        if (CheckCollisionRecs(hitbox, entity->hitbox)) {
-
-            /*
-                TODO: Click closer to the ground and still place the enemy.
-                
-                If the collision is with a block (create a block component btw),
-                but the y of the block is below the mouse, change the hitbox
-                to be right above the ground.
-
-                It will need to check for collisions again, and be careful about
-                not entering infinite loops.
-            */
-
-            TraceLog(LOG_DEBUG, "Couldn't add enemy to level, collision with entity on x=%.1f, y=%.1f.",
-                entity->hitbox.x, entity->hitbox.y);
-            return;
-        }
-
-        node = node->next;
-
+    if (LevelCheckCollisionWithAnythingElse(hitbox)) {
+        TraceLog(LOG_DEBUG, "Couldn't add enemy to level, collision with entity.");
+        return;
     }
 
     LevelEnemyAdd((Vector2){ hitbox.x, hitbox.y });

--- a/src/level/enemy.c
+++ b/src/level/enemy.c
@@ -3,6 +3,7 @@
 #include "../linked_list.h"
 #include "../core.h"
 #include "level.h"
+#include "../render.h"
 
 #define ENEMY_SPEED_DEFAULT 4.0f
 #define ENEMY_FALL_RATE 7.0f
@@ -65,8 +66,9 @@ void LevelEnemyTick(ListNode *enemyNode) {
 
     if (levelConcludedAgo >= 0) return;
 
-
     LevelEntity *enemy = (LevelEntity *)enemyNode->item;
+    if (enemy->isDead) return;
+
 
     LevelEntity *groundBeneath = LevelGetGroundBeneath(enemy);
 
@@ -114,5 +116,9 @@ void LevelEnemyTick(ListNode *enemyNode) {
 void LevelEnemyKill(LevelEntity *entity) {
 
     entity->isDead = true;
+
+    RenderShowEntityInfoStop(); // gambiarra
+
+
     TraceLog(LOG_TRACE, "Enemy died.");
 }

--- a/src/level/level.c
+++ b/src/level/level.c
@@ -125,7 +125,6 @@ void LevelExitAdd(Vector2 pos) {
 
 void LevelExitCheckAndAdd(Vector2 pos) {
     
-    ListNode *node = LEVEL_LIST_HEAD;
     Rectangle hitbox = SpriteHitboxFromMiddle(LevelEndOrbSprite, pos);
 
     if (LevelCheckCollisionWithAnythingElse(hitbox)) {

--- a/src/level/level.c
+++ b/src/level/level.c
@@ -55,7 +55,7 @@ void LevelInitialize(char *levelName) {
     GameStateReset();
     STATE->mode = MODE_IN_LEVEL;
 
-    LinkedListRemoveAll(&LEVEL_LIST_HEAD);
+    LinkedListDestroyAll(&LEVEL_LIST_HEAD);
     LEVEL_PLAYER = 0;
     levelExitNode = 0;
 
@@ -79,8 +79,6 @@ void LevelInitialize(char *levelName) {
 
     CameraFollow();
 
-    RenderShowEntityInfoStop();
-
     RenderLevelTransitionEffectStart(
         SpritePosMiddlePoint(
             (Vector2){LEVEL_PLAYER->hitbox.x, LEVEL_PLAYER->hitbox.y}, LEVEL_PLAYER->sprite), false);
@@ -100,6 +98,8 @@ void LevelGoToOverworld() {
     RenderLevelTransitionEffectStart(
         SpritePosMiddlePoint(
             (Vector2){LEVEL_PLAYER->hitbox.x, LEVEL_PLAYER->hitbox.y}, LEVEL_PLAYER->sprite), true);
+
+    RenderDebugEntityStopAll();
 
     levelConcludedAgo = GetTime();
 }
@@ -145,7 +145,7 @@ void LevelExitCheckAndAdd(Vector2 pos) {
     }
 
     // Currently only one level exit is supported, but this should change in the future.
-    if (levelExitNode) LinkedListRemove(&LEVEL_LIST_HEAD, levelExitNode);
+    if (levelExitNode) LinkedListDestroyNode(&LEVEL_LIST_HEAD, levelExitNode);
     
     LevelExitAdd((Vector2){ hitbox.x, hitbox.y });
 }
@@ -200,9 +200,9 @@ void LevelEntityDestroy(ListNode *node) {
 
     if (node == levelExitNode) levelExitNode = 0;
 
-    RenderShowEntityInfoStop(); // gambiarra
+    RenderDebugEntityStop((LevelEntity *) node->item);
 
-    LinkedListRemove(&LEVEL_LIST_HEAD, node);
+    LinkedListDestroyNode(&LEVEL_LIST_HEAD, node);
 
     TraceLog(LOG_TRACE, "Destroyed level entity.");
 }

--- a/src/level/level.h
+++ b/src/level/level.h
@@ -135,6 +135,10 @@ void LevelEnemyCheckAndAdd(Vector2 origin);
 
 void LevelEnemyTick(ListNode *enemyNode);
 
+// Checks for collision between a rectangle and any other entity in the level,
+// including its origin.
+bool LevelCheckCollisionWithAnythingElse(Rectangle hitbox);
+
 void LevelEnemyKill(LevelEntity *entity);
 
 void LevelBlockAdd(Vector2 origin);

--- a/src/linked_list.c
+++ b/src/linked_list.c
@@ -31,7 +31,15 @@ ListNode *LinkedListAdd(ListNode **head, void *item) {
     return node;
 }
 
-void LinkedListRemove(ListNode **head, ListNode *node) {
+void LinkedListDestroyNode(ListNode **head, ListNode *node) {
+
+    MemFree(node->item);
+    LinkedListRemoveNode(head, node);
+
+    TraceLog(LOG_TRACE, "Destroyed node with item from linked list.");
+}
+
+void LinkedListRemoveNode(ListNode **head, ListNode *node) {
 
     if (*head == node) {
         *head = node->next;
@@ -39,11 +47,9 @@ void LinkedListRemove(ListNode **head, ListNode *node) {
 
     if (node->next) node->next->previous = node->previous;
     if (node->previous) node->previous->next = node->next;
-
-    if (node->item) MemFree(node->item);
     MemFree(node);
 
-    TraceLog(LOG_TRACE, "Removed item from linked list and destroyed it.");
+    TraceLog(LOG_TRACE, "Destroyed node from linked list.");
 }
 
 ListNode *LinkedListGetNode(ListNode *head, void *item) {
@@ -57,13 +63,27 @@ ListNode *LinkedListGetNode(ListNode *head, void *item) {
     return head;
 }
 
-void LinkedListRemoveAll(ListNode **head) {
+void LinkedListDestroyAll(ListNode **head) {
 
     while (*head) {
-        LinkedListRemove(head, *head);
+        LinkedListDestroyNode(head, *head);
     }
 
-    TraceLog(LOG_TRACE, "Removed all items from linked list and destroyed them.");
+    TraceLog(LOG_TRACE, "Destroyed a linked list.");
+}
+
+void LinkedListRemoveAll(ListNode **head) {
+
+    ListNode *node = *head;
+    while (node) {
+        ListNode *next = node->next;
+        MemFree(node);
+        node = next;
+    }
+
+    *head = 0;
+
+    TraceLog(LOG_TRACE, "Removed all items from a linked list.");
 }
 
 int LinkedListCountNodes(ListNode *head) {

--- a/src/linked_list.h
+++ b/src/linked_list.h
@@ -16,10 +16,16 @@ ListNode *LinkedListAdd(ListNode **head, void *item);
 // Returns list node containing item, or 0 if not found.
 ListNode *LinkedListGetNode(ListNode *head, void *item);
 
-// Removes and destroys node from a linked list.
-void LinkedListRemove(ListNode **head, ListNode *node);
+// Removes and destroys node, with its item, from a linked list.
+void LinkedListDestroyNode(ListNode **head, ListNode *node);
 
-// Removes and destroys all nodes from a linked list.
+// Removes and destroys all nodes, with its items, from a linked list.
+void LinkedListDestroyAll(ListNode **head);
+
+// Removes and destroys a node from a linked list, but doesn't destroy its item.
+void LinkedListRemoveNode(ListNode **head, ListNode *node);
+
+// Removes all nodes from a linked list, but doesn't destroy the items.
 void LinkedListRemoveAll(ListNode **head);
 
 // Counts how many nodes there are in a linked list.

--- a/src/overworld.c
+++ b/src/overworld.c
@@ -45,7 +45,7 @@ static void destroyEntityOverworld(ListNode *node) {
     OverworldEntity *entity = (OverworldEntity *) node->item;
     MemFree(entity->levelName);
 
-    LinkedListRemove(&OW_LIST_HEAD, node);
+    LinkedListDestroyNode(&OW_LIST_HEAD, node);
 
     TraceLog(LOG_TRACE, "Destroyed overworld entity.");
 }
@@ -188,8 +188,6 @@ void OverworldInitialize() {
     CameraFollow();
 
     memset(STATE->loadedLevel, 0, sizeof(STATE->loadedLevel));
-
-    RenderShowEntityInfoStop();
 
     RenderLevelTransitionEffectStart(
         SpritePosMiddlePoint(OW_CURSOR->gridPos, OW_CURSOR->sprite), false);

--- a/src/render.c
+++ b/src/render.c
@@ -550,7 +550,7 @@ void RenderDebugEntityToggle(LevelEntity *entity) {
     ListNode *entitysNode = LinkedListGetNode(DEBUG_ENTITY_INFO_HEAD, entity);
 
     if (entitysNode) {
-        LinkedListRemoveNode(&DEBUG_ENTITY_INFO_HEAD, entity);
+        LinkedListRemoveNode(&DEBUG_ENTITY_INFO_HEAD, entitysNode);
         TraceLog(LOG_TRACE, "Debug entity info removed entity;");
     } else {
         LinkedListAdd(&DEBUG_ENTITY_INFO_HEAD, entity);

--- a/src/render.c
+++ b/src/render.c
@@ -36,12 +36,12 @@ typedef struct LevelTransitionShaderControl {
 
 ListNode *SYS_MESSAGES_HEAD = 0;
 
+ListNode *DEBUG_ENTITY_INFO_HEAD = 0;
+
+
 // Texture covering the whole screen, used to render shaders
 static RenderTexture2D shaderRenderTexture;
 static LevelTransitionShaderControl levelTransitionShaderControl;
-
-// Debugging
-static LevelEntity *levelEntityShowInfo = 0;
 
 
 static void drawTexture(Sprite sprite, Vector2 pos, Color tint, bool flipHorizontally) {
@@ -226,7 +226,7 @@ static void drawSysMessages() {
 
         if (msg->secondsUntilDisappear <= 0) {
             MemFree(msg->msg);
-            LinkedListRemove(&SYS_MESSAGES_HEAD, node);
+            LinkedListDestroyNode(&SYS_MESSAGES_HEAD, node);
             goto next_node;
         }        
 
@@ -319,22 +319,35 @@ static void drawDebugHud() {
         DrawText(buffer, 600, 20, 20, WHITE);
     }
 
-    if (levelEntityShowInfo) {
+    ListNode *node = DEBUG_ENTITY_INFO_HEAD;
+    while (node != 0) {
+        LevelEntity *entity = (LevelEntity *) node->item;
+        ListNode *nextNode = node->next;
+
+        if (!entity) { // Destroyed
+            LinkedListRemoveNode(&DEBUG_ENTITY_INFO_HEAD, node);
+            TraceLog(LOG_TRACE, "Debug entity info stopped showing entity.");
+            goto next_node;
+        }
+
         Vector2 pos = PosInSceneToScreen((Vector2) {
-                                            levelEntityShowInfo->hitbox.x,
-                                            levelEntityShowInfo->hitbox.y
+                                            entity->hitbox.x,
+                                            entity->hitbox.y
                                         });
 
         DrawRectangle(pos.x, pos.y,
-                levelEntityShowInfo->hitbox.width, levelEntityShowInfo->hitbox.height, (Color){ GREEN.r, GREEN.g, GREEN.b, 128 });
+                entity->hitbox.width, entity->hitbox.height, (Color){ GREEN.r, GREEN.g, GREEN.b, 128 });
         DrawRectangleLines(pos.x, pos.y,
-                levelEntityShowInfo->hitbox.width, levelEntityShowInfo->hitbox.height, GREEN);
+                entity->hitbox.width, entity->hitbox.height, GREEN);
 
         char buffer[500];
         sprintf(buffer, "X=%.1f\nY=%.1f",
-                    levelEntityShowInfo->hitbox.x,
-                    levelEntityShowInfo->hitbox.y);
+                    entity->hitbox.x,
+                    entity->hitbox.y);
         DrawText(buffer, pos.x, pos.y, 25, WHITE);
+
+next_node:
+        node = nextNode;
     }
 }
 
@@ -532,10 +545,28 @@ void RenderLevelTransitionEffectStart(Vector2 sceneFocusPoint, bool isClose) {
     levelTransitionShaderControl.focusPoint.y = GetScreenHeight() - levelTransitionShaderControl.focusPoint.y;
 }
 
-void RenderShowEntityInfo(LevelEntity *entity) {
-    levelEntityShowInfo = entity;
+void RenderDebugEntityToggle(LevelEntity *entity) {
+    
+    ListNode *entitysNode = LinkedListGetNode(DEBUG_ENTITY_INFO_HEAD, entity);
+
+    if (entitysNode) {
+        LinkedListRemoveNode(&DEBUG_ENTITY_INFO_HEAD, entity);
+        TraceLog(LOG_TRACE, "Debug entity info removed entity;");
+    } else {
+        LinkedListAdd(&DEBUG_ENTITY_INFO_HEAD, entity);
+        TraceLog(LOG_TRACE, "Debug entity info added entity;");
+    }
 }
 
-void RenderShowEntityInfoStop() {
-    levelEntityShowInfo = 0;
+void RenderDebugEntityStop(LevelEntity *entity) {
+    ListNode *entitysNode = LinkedListGetNode(DEBUG_ENTITY_INFO_HEAD, entity);
+    if (entitysNode) {
+        LinkedListRemoveNode(&DEBUG_ENTITY_INFO_HEAD, entitysNode);
+        TraceLog(LOG_TRACE, "Debug entity info stopped showing entity.");
+    }
+}
+
+void RenderDebugEntityStopAll() {
+    LinkedListRemoveAll(&DEBUG_ENTITY_INFO_HEAD);
+    TraceLog(LOG_TRACE, "Debug entity info stopped showing all entities.");
 }

--- a/src/render.h
+++ b/src/render.h
@@ -26,11 +26,14 @@ void RenderPrintSysMessage(char *msg);
 */
 void RenderLevelTransitionEffectStart(Vector2 sceneFocusPont, bool isClose);
 
-// Starts showing info about the provided level entity, for debugging
-void RenderShowEntityInfo(LevelEntity *entity);
+// Shows info about entity, or stop showing if it's there already.
+void RenderDebugEntityToggle(LevelEntity *entity);
 
-// Stops showing info about level entity
-void RenderShowEntityInfoStop();
+// Stops showing info about an entity. If it's not showing already, does nothing.
+void RenderDebugEntityStop(LevelEntity *entity);
+
+// Stops showing info about all entities.
+void RenderDebugEntityStopAll();
 
 
 #endif // _RENDER_H_INCLUDED_


### PR DESCRIPTION
Added support for the Debug Entity info HUD to enable multiple entities at the same time. This demanded modifications to the linked list code, expanding it with functions to only destroy nodes without destroying its items.

Improved the functions that place entities on level through the editor by centralizing its collision checking algorithms all in one place. Not only this made the code clearer and cleaner, but also made the behavior of placing enemies on the editor more consistent.

Solved some general bugs.