### PR TITLE
Fix bug placing blocks with the editor

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -24,7 +24,7 @@ static inline float snapToGrid(float value, float length) {
     }
 }
 
-static inline float pushOnGrid(float value, float length) {
+static inline float distanceFromGrid(float value, float length) {
 
     if (value >= 0) {
         return length - fmod(value, length);
@@ -145,10 +145,10 @@ Vector2 SnapToGrid(Vector2 coords, Dimensions grid) {
     };
 }
 
-Vector2 PushOnGrid(Vector2 coords, Dimensions grid) {
+Vector2 DistanceFromGrid(Vector2 coords, Dimensions grid) {
 
     return (Vector2) {
-        pushOnGrid(coords.x, grid.width),
-        pushOnGrid(coords.y, grid.height)
+        distanceFromGrid(coords.x, grid.width),
+        distanceFromGrid(coords.y, grid.height)
     };
 }

--- a/src/core.c
+++ b/src/core.c
@@ -15,6 +15,24 @@ GameState *STATE = 0;
 static size_t mouseEnabledReferences = 0;
 
 
+static inline float snapToGrid(float value, float length) {
+
+    if (value >= 0) {
+        return value - fmod(value, length);
+    } else {
+        return value - length - fmod(value, length);
+    }
+}
+
+static inline float pushOnGrid(float value, float length) {
+
+    if (value >= 0) {
+        return length - fmod(value, length);
+    } else {
+        return - length - fmod(value, length);
+    }
+}
+
 void GameStateInitialize() {
     STATE = MemAlloc(sizeof(GameState));
 
@@ -119,20 +137,18 @@ bool IsInPlayArea(Vector2 pos) {
             pos.y <= SCREEN_HEIGHT;
 }
 
-float SnapToGrid(float value, float length) {
+Vector2 SnapToGrid(Vector2 coords, Dimensions grid) {
 
-    if (value >= 0) {
-        return value - fmod(value, length);
-    } else {
-        return value - length - fmod(value, length);
-    }
+    return (Vector2) {
+        snapToGrid(coords.x, grid.width),
+        snapToGrid(coords.y, grid.height)
+    };
 }
 
-float PushOnGrid(float value, float length) {
+Vector2 PushOnGrid(Vector2 coords, Dimensions grid) {
 
-    if (value >= 0) {
-        return length - fmod(value, length);
-    } else {
-        return - length - fmod(value, length);
-    }
+    return (Vector2) {
+        pushOnGrid(coords.x, grid.width),
+        pushOnGrid(coords.y, grid.height)
+    };
 }

--- a/src/core.h
+++ b/src/core.h
@@ -81,8 +81,8 @@ void DebugHudToggle();
 // Snaps a point to its place (top-left) in a grid.
 Vector2 SnapToGrid(Vector2 coords, Dimensions grid);
 
-// Pushes a point away from its place (top=left) in a grid.
-Vector2 PushOnGrid(Vector2 coords, Dimensions grid);
+// The distance between a point and the closest (bottom-right) point of a grid.
+Vector2 DistanceFromGrid(Vector2 coords, Dimensions grid);
 
 
 #endif // _CORE_H_INCLUDED_

--- a/src/core.h
+++ b/src/core.h
@@ -78,11 +78,11 @@ void MouseCursorEnable();
 // Toggles the debug HUD between 'enabled' and 'disabled'
 void DebugHudToggle();
 
-// Snaps a coordinate (x or y) to a grid.
-float SnapToGrid(float value, float length);
+// Snaps a point to its place (top-left) in a grid.
+Vector2 SnapToGrid(Vector2 coords, Dimensions grid);
 
-// Pushes a coordinate (x or y) according to a grid.
-float PushOnGrid(float value, float length);
+// Pushes a point away from its place (top=left) in a grid.
+Vector2 PushOnGrid(Vector2 coords, Dimensions grid);
 
 
 #endif // _CORE_H_INCLUDED_

--- a/src/editor.c
+++ b/src/editor.c
@@ -55,7 +55,7 @@ void loadInLevelEditor() {
 
 void loadOverworldEditor() {
 
-    loadEditorEntityItem(EDITOR_ENTITY_ERASER, EraserSprite, &OverworldTileRemoveAt, EDITOR_INTERACTION_CLICK);
+    loadEditorEntityItem(EDITOR_ENTITY_ERASER, EraserSprite, &OverworldTileRemoveAt, EDITOR_INTERACTION_HOLD);
     STATE->editorSelectedEntity =
         loadEditorEntityItem(EDITOR_ENTITY_LEVEL_DOT, LevelDotSprite, &OverworldTileAddOrInteract, EDITOR_INTERACTION_CLICK);
     loadEditorEntityItem(EDITOR_ENTITY_PATH_JOIN, PathTileJoinSprite, &OverworldTileAddOrInteract, EDITOR_INTERACTION_CLICK);

--- a/src/level/block.c
+++ b/src/level/block.c
@@ -8,8 +8,6 @@ void LevelBlockAdd(Vector2 origin) {
 
     LevelEntity *newBlock = MemAlloc(sizeof(LevelEntity));
 
-    origin = SnapToGrid(origin, LEVEL_GRID);
-
     newBlock->components = LEVEL_IS_SCENARIO +
                             LEVEL_IS_GROUND;
     newBlock->origin = origin;
@@ -24,7 +22,10 @@ void LevelBlockAdd(Vector2 origin) {
 
 void LevelBlockCheckAndAdd(Vector2 origin) {
 
-    Rectangle hitbox = SpriteHitboxFromMiddle(BlockSprite, origin);
+    origin = SnapToGrid(origin, LEVEL_GRID);
+
+    Rectangle hitbox = SpriteHitboxFromEdge(BlockSprite, origin);
     if (LevelCheckCollisionWithAnythingElse(hitbox)) return;
+    
     LevelBlockAdd(origin);
 }

--- a/src/level/block.c
+++ b/src/level/block.c
@@ -8,8 +8,7 @@ void LevelBlockAdd(Vector2 origin) {
 
     LevelEntity *newBlock = MemAlloc(sizeof(LevelEntity));
 
-    origin.x = SnapToGrid(origin.x, LEVEL_GRID.width);
-    origin.y = SnapToGrid(origin.y, LEVEL_GRID.height);
+    origin = SnapToGrid(origin, LEVEL_GRID);
 
     newBlock->components = LEVEL_IS_SCENARIO +
                             LEVEL_IS_GROUND;

--- a/src/overworld.c
+++ b/src/overworld.c
@@ -126,11 +126,8 @@ OverworldEntity *OverworldTileAdd(Vector2 pos, OverworldTileType type, int degre
 
     OverworldEntity *newTile = MemAlloc(sizeof(OverworldEntity));
 
-    pos.x = SnapToGrid(pos.x, OW_GRID.width);
-    pos.y = SnapToGrid(pos.y, OW_GRID.height);
-
     newTile->tileType = type;
-    newTile->gridPos = pos;
+    newTile->gridPos = SnapToGrid(pos, OW_GRID);
     newTile->levelName = MemAlloc(sizeof(char) * LEVEL_NAME_BUFFER_SIZE);
 
     switch (newTile->tileType)
@@ -277,8 +274,9 @@ next_entity:
 
 void OverworldTileAddOrInteract(Vector2 pos) {
 
-    Rectangle testHitbox = (Rectangle){ SnapToGrid(pos.x, OW_GRID.width),
-                                    SnapToGrid(pos.y, OW_GRID.height),
+    pos = SnapToGrid(pos, OW_GRID);
+    Rectangle testHitbox = (Rectangle){ pos.x,
+                                    pos.y,
                                     OW_GRID.width,
                                     OW_GRID.width };
 

--- a/src/render.c
+++ b/src/render.c
@@ -245,21 +245,18 @@ next_node:
 
 static void drawDebugGrid() {
 
-    Dimensions gridSquareDim;
-    if (STATE->mode == MODE_OVERWORLD) gridSquareDim = OW_GRID;
-    else if (STATE->mode == MODE_IN_LEVEL) gridSquareDim = LEVEL_GRID;
+    Dimensions grid;
+    if (STATE->mode == MODE_OVERWORLD) grid = OW_GRID;
+    else if (STATE->mode == MODE_IN_LEVEL) grid = LEVEL_GRID;
     else return;
 
-    Vector2 offset = (Vector2){
-        PushOnGrid(CAMERA->pos.x, gridSquareDim.width),
-        PushOnGrid(CAMERA->pos.y, gridSquareDim.height),
-    };
+    Vector2 offset = PushOnGrid(CAMERA->pos, grid);
 
-    for (float lineX = offset.x; lineX <= SCREEN_WIDTH; lineX += gridSquareDim.width) {
+    for (float lineX = offset.x; lineX <= SCREEN_WIDTH; lineX += grid.width) {
         DrawLine(lineX, 0, lineX, SCREEN_HEIGHT, BLUE);
     }
 
-    for (float lineY = offset.y; lineY <= SCREEN_HEIGHT; lineY += gridSquareDim.height) {
+    for (float lineY = offset.y; lineY <= SCREEN_HEIGHT; lineY += grid.height) {
         DrawLine(0, lineY, SCREEN_WIDTH, lineY, BLUE);
     }
 }

--- a/src/render.c
+++ b/src/render.c
@@ -250,7 +250,7 @@ static void drawDebugGrid() {
     else if (STATE->mode == MODE_IN_LEVEL) grid = LEVEL_GRID;
     else return;
 
-    Vector2 offset = PushOnGrid(CAMERA->pos, grid);
+    Vector2 offset = DistanceFromGrid(CAMERA->pos, grid);
 
     for (float lineX = offset.x; lineX <= SCREEN_WIDTH; lineX += grid.width) {
         DrawLine(lineX, 0, lineX, SCREEN_HEIGHT, BLUE);


### PR DESCRIPTION
Supposedly after the PR #117 a bug came up where some blocks wouldn't be placed in the grid. It was fixed by snapping its pos to the grid and calculating the hitbox from edge before checking for collisions.

Together with it, it felt like a good opportunity to simplify the API to the grid (snap and push) functions in core.h. Now they work with vectors instead of simple points.

The editor's eraser now work by holding it in the overworld.