### PR TITLE
Moved 'Dimensions' definition to core.h and fixed subsequent circular dependencies problems

### DIFF
--- a/src/assets.h
+++ b/src/assets.h
@@ -3,6 +3,7 @@
 
 
 #include <raylib.h>
+#include "core.h"
 
 
 typedef struct Sprite {
@@ -10,11 +11,6 @@ typedef struct Sprite {
     float scale;
     int rotation;
 } Sprite;
-
-typedef struct Dimensions {
-    float width;
-    float height;
-} Dimensions;
 
 
 // Editor

--- a/src/camera.c
+++ b/src/camera.c
@@ -3,6 +3,8 @@
 #include "camera.h"
 #include "level/level.h"
 #include "core.h"
+#include "overworld.h"
+
 
 #define CAMERA_FOLLOW_LEFT      SCREEN_WIDTH/4
 #define CAMERA_FOLLOW_RIGHT     (3*SCREEN_WIDTH)/5

--- a/src/core.h
+++ b/src/core.h
@@ -1,12 +1,9 @@
 #ifndef _CORE_H_INCLUDED_
 #define _CORE_H_INCLUDED_
 
-
-#include "level/level.h"
-#include "editor.h"
+#include <raylib.h>
 #include "linked_list.h"
 #include "persistence.h"
-#include "overworld.h"
 
 // Currently this represents the play space (not including editor)
 #define SCREEN_WIDTH 1280
@@ -17,22 +14,31 @@
 #define FLOOR_DEATH_HEIGHT 800 // Below this y in level the player dies
 
 
+struct EditorEntityItem;
+struct OverworldEntity;
+
+typedef struct Dimensions {
+    float width;
+    float height;
+} Dimensions;
+
 typedef enum GameMode {
     MODE_IN_LEVEL,
     MODE_OVERWORLD
 } GameMode;
 
 typedef struct GameState {
+
     GameMode mode;
 
     char loadedLevel[LEVEL_NAME_BUFFER_SIZE];
 
     bool isPaused;
 
-    EditorEntityItem *editorSelectedEntity;
+    struct EditorEntityItem *editorSelectedEntity;
     bool isEditorEnabled;
 
-    OverworldEntity *tileUnderCursor;
+    struct OverworldEntity *tileUnderCursor;
     
     // If selected a dot in the OW without an associated level
     bool expectingLevelAssociation;

--- a/src/level/level.c
+++ b/src/level/level.c
@@ -1,11 +1,13 @@
 #include <raylib.h>
-#include "stdlib.h"
+#include <stdlib.h>
 #include <string.h>
 
 #include "level.h"
 #include "../core.h"
 #include "../camera.h"
 #include "../render.h"
+#include "../editor.h"
+#include "../overworld.h"
 
 
 // The difference between the y of the hitbox and the ground to be considered "on the ground"

--- a/src/level/level.h
+++ b/src/level/level.h
@@ -6,6 +6,7 @@
 
 #include "../linked_list.h"
 #include "../assets.h"
+#include "../core.h"
 
 
 #define NEW_LEVEL_NAME "default_new_level.lvl"

--- a/src/overworld.c
+++ b/src/overworld.c
@@ -8,6 +8,7 @@
 #include "camera.h"
 #include "render.h"
 #include "persistence.h"
+#include "editor.h"
 
 
 ListNode *OW_LIST_HEAD = 0;

--- a/src/overworld.h
+++ b/src/overworld.h
@@ -5,6 +5,7 @@
 #include "assets.h"
 #include "linked_list.h"
 #include "persistence.h"
+#include "core.h"
 
 
 #define OW_GRID (Dimensions){ 64, 64 }


### PR DESCRIPTION
For the first time in this project I've ran into circular dependencies problems.

This happened because I moved the Dimensions type definition to core.h.

I had to create some forward declarations in core.h so I could have it depend on fewer header files.

Some other adjusts had to be made.