### PR TITLE
Move the player's current pos in the level while editing or debugging

### DIFF
--- a/src/input.c
+++ b/src/input.c
@@ -71,6 +71,14 @@ void handleDevInput() {
 
     if      (!IsInPlayArea(mousePosInScreen)) return;
 
+    if (STATE->showDebugHUD || STATE->isEditorEnabled) {
+
+        if (IsKeyDown(KEY_SPACE) && IsMouseButtonPressed(MOUSE_BUTTON_LEFT)) {
+            LevelPlayerCheckAndSetPos(mousePosInScene);
+            return;
+        }
+    }
+
     if (STATE->isEditorEnabled) {
 
         if (IsMouseButtonDown(MOUSE_BUTTON_LEFT)) {

--- a/src/level/block.c
+++ b/src/level/block.c
@@ -42,7 +42,7 @@ void LevelBlockCheckAndAdd(Vector2 origin) {
     origin = SnapToGrid(origin, LEVEL_GRID);
 
     Rectangle hitbox = SpriteHitboxFromEdge(BlockSprite, origin);
-    if (LevelCheckCollisionWithAnythingElse(hitbox)) return;
+    if (LevelCheckCollisionWithAnyEntityOrOrigin(hitbox)) return;
     
     LevelBlockAdd(origin);
 }
@@ -52,7 +52,7 @@ void LevelAcidCheckAndAdd(Vector2 origin) {
     origin = SnapToGrid(origin, LEVEL_GRID);
 
     Rectangle hitbox = SpriteHitboxFromEdge(AcidSprite, origin);
-    if (LevelCheckCollisionWithAnythingElse(hitbox)) return;
+    if (LevelCheckCollisionWithAnyEntityOrOrigin(hitbox)) return;
     
     LevelAcidAdd(origin);
 }

--- a/src/level/enemy.c
+++ b/src/level/enemy.c
@@ -32,7 +32,7 @@ void LevelEnemyCheckAndAdd(Vector2 origin) {
 
     Rectangle hitbox = SpriteHitboxFromMiddle(EnemySprite, origin);
 
-    if (LevelCheckCollisionWithAnythingElse(hitbox)) {
+    if (LevelCheckCollisionWithAnyEntityOrOrigin(hitbox)) {
         TraceLog(LOG_DEBUG, "Couldn't add enemy to level, collision with entity.");
         return;
     }

--- a/src/level/level.c
+++ b/src/level/level.c
@@ -129,7 +129,7 @@ void LevelExitCheckAndAdd(Vector2 pos) {
     
     Rectangle hitbox = SpriteHitboxFromMiddle(LevelEndOrbSprite, pos);
 
-    if (LevelCheckCollisionWithAnythingElse(hitbox)) {
+    if (LevelCheckCollisionWithAnyEntityOrOrigin(hitbox)) {
         TraceLog(LOG_DEBUG, "Couldn't add level exit, collision with entity.");
         return;
     }
@@ -271,7 +271,27 @@ skip_entities_tick:
     CameraTick();
 }
 
-bool LevelCheckCollisionWithAnythingElse(Rectangle hitbox) {
+bool LevelCheckCollisionWithAnyEntity(Rectangle hitbox) {
+
+    ListNode *node = LEVEL_LIST_HEAD;
+
+    while (node != 0) {
+    
+        LevelEntity *entity = (LevelEntity *) node->item;
+
+        if (!(entity->isDead) && CheckCollisionRecs(hitbox, entity->hitbox)) {
+
+            return true;
+        }
+
+        node = node->next;
+
+    }
+
+    return false;
+}
+
+bool LevelCheckCollisionWithAnyEntityOrOrigin(Rectangle hitbox) {
 
     ListNode *node = LEVEL_LIST_HEAD;
 

--- a/src/level/level.h
+++ b/src/level/level.h
@@ -139,6 +139,9 @@ void LevelPlayerSetMode(PlayerMode mode);
 // For debugging -- Sets a respawn flag in the level. Will respawn there.
 void LevelPlayerSetRespawn();
 
+// Moves the player to pos, if there aren't other things there already.
+void LevelPlayerCheckAndSetPos(Vector2 pos);
+
 
 // Initializes and adds an enemy to the level in the given origin
 void LevelEnemyAdd(Vector2 origin);
@@ -149,9 +152,13 @@ void LevelEnemyCheckAndAdd(Vector2 origin);
 
 void LevelEnemyTick(ListNode *enemyNode);
 
-// Checks for collision between a rectangle and any other entity in the level,
-// including its origin.
-bool LevelCheckCollisionWithAnythingElse(Rectangle hitbox);
+// Checks for collision between a rectangle and any 
+// living entity in the level.
+bool LevelCheckCollisionWithAnyEntity(Rectangle hitbox);
+
+// Checks for collision between a rectangle and any 
+// living entity in the level, including their origins.
+bool LevelCheckCollisionWithAnyEntityOrOrigin(Rectangle hitbox);
 
 void LevelEnemyKill(LevelEntity *entity);
 

--- a/src/level/player.c
+++ b/src/level/player.c
@@ -407,3 +407,18 @@ void LevelPlayerSetRespawn() {
     TraceLog(LOG_INFO, "Player set respawn to x=%.1f, y=%.1f.", respawnFlag.x, respawnFlag.y);
     RenderPrintSysMessage("[debug] Definido ponto de renascimento.");
 }
+
+void LevelPlayerCheckAndSetPos(Vector2 pos) {
+
+    Rectangle hitbox = SpriteHitboxFromMiddle(LEVEL_PLAYER->sprite, pos);
+    
+    if (LevelCheckCollisionWithAnyEntity(hitbox)) {
+        TraceLog(LOG_DEBUG, "Player couldn't be set to pos x=%.1f, y=%.1f; would collide with a different entity.");
+        RenderPrintSysMessage("[debug] Jogador iria colidir.");
+        return;
+    }
+    
+    LEVEL_PLAYER->hitbox = hitbox;
+    syncPlayersHitboxes();
+    TraceLog(LOG_DEBUG, "Player set to pos x=%.1f, y=%.1f.");
+}


### PR DESCRIPTION
Hold space and left click to move the player around the level while in Edit or Debug mode. It will check for collisions with other level entities (though not their origins).