### PR TITLE
Editor selection

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,6 +13,7 @@
         "xstring": "c",
         "xutility": "c",
         "stdlib.h": "c",
-        "string.h": "c"
+        "string.h": "c",
+        "editor.h": "c"
     }
 }

--- a/src/core.c
+++ b/src/core.c
@@ -81,6 +81,9 @@ void GameUpdate() {
     else if (STATE->mode == MODE_OVERWORLD)
         OverworldTick();
 
+    if (STATE->isEditorEnabled)
+        EditorTick();
+
     windowTitleUpdate();
 }
 

--- a/src/editor.c
+++ b/src/editor.c
@@ -88,10 +88,11 @@ static void updateEntitySelectionList() {
 
         if (STATE->mode == MODE_IN_LEVEL) {
             LevelEntity *entity = (LevelEntity *) node->item;
-            if ((!entity->isDead && CheckCollisionRecs(selectionHitbox, entity->hitbox)) ||
-                CheckCollisionRecs(selectionHitbox, LevelEntityOriginHitbox(entity))) {
+            bool collisionWithEntity = !entity->isDead && CheckCollisionRecs(selectionHitbox, entity->hitbox);
+            bool collisionWithGhost = CheckCollisionRecs(selectionHitbox, LevelEntityOriginHitbox(entity));
+            if (collisionWithEntity || collisionWithGhost) {
                 
-                    LinkedListAdd(&EDITOR_ENTITY_SELECTION->entitiesHead, entity);
+                LinkedListAdd(&EDITOR_ENTITY_SELECTION->entitiesHead, entity);
             }
         }
         else if (STATE->mode == MODE_OVERWORLD) {

--- a/src/editor.c
+++ b/src/editor.c
@@ -106,23 +106,12 @@ static void updateEntitySelectionList() {
     }
 }
 
-static void clearEntitySelection() {
-
-    if (EDITOR_ENTITY_SELECTION) {
-        LinkedListRemoveAll(&EDITOR_ENTITY_SELECTION->entitiesHead);
-        MemFree(EDITOR_ENTITY_SELECTION);
-        EDITOR_ENTITY_SELECTION = 0;
-    }
-
-    TraceLog(LOG_TRACE, "Editor's entity selection cleared.");
-}
-
 void EditorSync() {
 
     LinkedListDestroyAll(&EDITOR_ENTITIES_HEAD);
     LinkedListDestroyAll(&EDITOR_CONTROL_HEAD);
     
-    clearEntitySelection();
+    EditorSelectionCancel();
 
     switch (STATE->mode) {
     
@@ -168,7 +157,7 @@ void EditorDisable() {
 
     CameraPanningReset();
 
-    clearEntitySelection();
+    EditorSelectionCancel();
 
     TraceLog(LOG_TRACE, "Editor disabled.");
 }
@@ -186,7 +175,7 @@ void EditorTick() {
         if (selectedEntitiesThisFrame)
             updateEntitySelectionList();
         else
-            clearEntitySelection();
+            EDITOR_ENTITY_SELECTION->isSelecting = false;
     }
     selectedEntitiesThisFrame = false;
 }
@@ -197,9 +186,25 @@ void EditorSelectEntities(Vector2 cursorPos) {
         EDITOR_ENTITY_SELECTION = MemAlloc(sizeof(EditorSelection));
         EDITOR_ENTITY_SELECTION->origin = cursorPos;
     }
+
+    if (!EDITOR_ENTITY_SELECTION->isSelecting) {
+        EDITOR_ENTITY_SELECTION->origin = cursorPos;
+    }
     
     EDITOR_ENTITY_SELECTION->current = cursorPos;
+    EDITOR_ENTITY_SELECTION->isSelecting = true;
     selectedEntitiesThisFrame = true;
+}
+
+void EditorSelectionCancel() {
+    
+    if (EDITOR_ENTITY_SELECTION) {
+        LinkedListRemoveAll(&EDITOR_ENTITY_SELECTION->entitiesHead);
+        MemFree(EDITOR_ENTITY_SELECTION);
+        EDITOR_ENTITY_SELECTION = 0;
+    }
+
+    TraceLog(LOG_TRACE, "Editor's entity selection canceled.");
 }
 
 Rectangle EditorEntityButtonRect(int buttonNumber) {

--- a/src/editor.c
+++ b/src/editor.c
@@ -212,24 +212,35 @@ void EditorSelectionCancel() {
 
 Rectangle EditorEntityButtonRect(int buttonNumber) {
 
-    float itemX = EDITOR_ENTITIES_AREA.x + ENTITY_BUTTON_WALL_SPACING;
-    if (buttonNumber % 2) itemX += ENTITY_BUTTON_SIZE + ENTITY_BUTTON_SPACING;
+    const Rectangle area        = EDITOR_ENTITIES_AREA;
+    const int buttonSize        = ENTITY_BUTTON_SIZE;
+    const int buttonSpacing     = ENTITY_BUTTON_SPACING;
+    const int wallSpacing       = ENTITY_BUTTON_WALL_SPACING;
 
-    float itemY = EDITOR_ENTITIES_AREA.y + ENTITY_BUTTON_WALL_SPACING;
-    itemY += (ENTITY_BUTTON_SIZE + ENTITY_BUTTON_SPACING) * (buttonNumber / 2);
+    float itemX = area.x + wallSpacing;
+    if (buttonNumber % 2) itemX += buttonSize + buttonSpacing;
 
-    return (Rectangle){ itemX, itemY, ENTITY_BUTTON_SIZE, ENTITY_BUTTON_SIZE };
+    float itemY = area.y + wallSpacing;
+    itemY += (buttonSize + buttonSpacing) * (buttonNumber / 2);
+
+    return (Rectangle){ itemX, itemY, buttonSize, buttonSize };
 }
 
 Rectangle EditorControlButtonRect(int buttonNumber) {
 
-    float itemX = EDITOR_CONTROL_AREA.x + CONTROL_BUTTON_WALL_SPACING;
-    if (buttonNumber % 2) itemX += CONTROL_BUTTON_WIDTH + CONTROL_BUTTON_SPACING;
+    const Rectangle area        = EDITOR_CONTROL_AREA;
+    const int buttonWidth       = CONTROL_BUTTON_WIDTH;
+    const int buttonHeight      = CONTROL_BUTTON_HEIGHT;
+    const int buttonSpacing     = CONTROL_BUTTON_SPACING;
+    const int wallSpacing       = CONTROL_BUTTON_WALL_SPACING;
 
-    float itemY = EDITOR_CONTROL_AREA.y + CONTROL_BUTTON_WALL_SPACING;
-    itemY += (CONTROL_BUTTON_HEIGHT + CONTROL_BUTTON_SPACING) * (buttonNumber / 2);
+    float itemX = area.x + wallSpacing;
+    if (buttonNumber % 2) itemX += buttonWidth + buttonSpacing;
 
-    return (Rectangle){ itemX, itemY, CONTROL_BUTTON_WIDTH, CONTROL_BUTTON_HEIGHT };
+    float itemY = area.y + wallSpacing;
+    itemY += (buttonHeight + buttonSpacing) * (buttonNumber / 2);
+
+    return (Rectangle){ itemX, itemY, buttonWidth, buttonHeight };
 }
 
 Rectangle EditorSelectionGetRect() {

--- a/src/editor.c
+++ b/src/editor.c
@@ -182,17 +182,20 @@ void EditorTick() {
 
 void EditorSelectEntities(Vector2 cursorPos) {
 
-    if (!EDITOR_ENTITY_SELECTION) {
+    EditorSelection *s = EDITOR_ENTITY_SELECTION;
+
+    if (!s) {
         EDITOR_ENTITY_SELECTION = MemAlloc(sizeof(EditorSelection));
-        EDITOR_ENTITY_SELECTION->origin = cursorPos;
+        s = EDITOR_ENTITY_SELECTION;
+        s->origin = cursorPos;
     }
 
-    if (!EDITOR_ENTITY_SELECTION->isSelecting) {
-        EDITOR_ENTITY_SELECTION->origin = cursorPos;
+    if (!s->isSelecting) {
+        s->origin = cursorPos;
     }
     
-    EDITOR_ENTITY_SELECTION->current = cursorPos;
-    EDITOR_ENTITY_SELECTION->isSelecting = true;
+    s->current = cursorPos;
+    s->isSelecting = true;
     selectedEntitiesThisFrame = true;
 }
 

--- a/src/editor.h
+++ b/src/editor.h
@@ -92,6 +92,7 @@ typedef struct EditorSelection {
 
     Vector2 origin;
     Vector2 current;
+    bool isSelecting;
     ListNode *entitiesHead;
 
 } EditorSelection;
@@ -125,6 +126,9 @@ void EditorTick();
 
 // Handles the selection of entities by a cursor dragging.
 void EditorSelectEntities(Vector2 cursorPos);
+
+// Cancels the selection of entities.
+void EditorSelectionCancel();
 
 // Calculates and returns an editor entity buttons' coordinates,
 // alongside its dimensions

--- a/src/editor.h
+++ b/src/editor.h
@@ -34,7 +34,12 @@
                                                 SCREEN_HEIGHT - EDITOR_ENTITIES_HEIGHT }
 
 // The background color of the editor
-#define EDITOR_BG_COLOR         (Color){ 0, 0, 0, 220 }
+#define EDITOR_BG_COLOR                 (Color){ 0, 0, 0, 220 }
+
+// The color of the entity selection
+#define EDITOR_SELECTION_RECT_COLOR     (Color){ BLUE.r, BLUE.g, BLUE.b, 64 }
+
+#define EDITOR_SELECTION_ENTITY_COLOR   (Color){ BLUE.r, BLUE.g, BLUE.b, 128 }
 
 
 typedef enum { 
@@ -82,11 +87,24 @@ typedef struct EditorControlItem {
 } EditorControlItem;
 
 
+// A selection of entities in the screen by a cursor.
+typedef struct EditorSelection {
+
+    Vector2 origin;
+    Vector2 current;
+    ListNode *entitiesHead;
+
+} EditorSelection;
+
+
 // The head of the linked list of all the loaded editor entity itens
 extern ListNode *EDITOR_ENTITIES_HEAD;
 
 // The head of the linked list of all the loaded editor control itens
 extern ListNode *EDITOR_CONTROL_HEAD;
+
+// Selection of entities in the screen by a cursor, if a selection is hapenning.
+extern EditorSelection *EDITOR_ENTITY_SELECTION;
 
 
 // Destroy any existing editor itens and then loads the items
@@ -103,6 +121,11 @@ void EditorDisable();
 // Enables and disables editor
 void EditorEnabledToggle();
 
+void EditorTick();
+
+// Handles the selection of entities by a cursor dragging.
+void EditorSelectEntities(Vector2 cursorPos);
+
 // Calculates and returns an editor entity buttons' coordinates,
 // alongside its dimensions
 Rectangle EditorEntityButtonRect(int buttonNumber);
@@ -110,5 +133,8 @@ Rectangle EditorEntityButtonRect(int buttonNumber);
 // Calculates and returns an editor entity buttons' coordinates,
 // alongside its dimensions
 Rectangle EditorControlButtonRect(int buttonNumber);
+
+// Gets the rectangle for the current editor's entity selection.
+Rectangle EditorSelectionGetRect();
 
 #endif // _EDITOR_H_INCLUDED_

--- a/src/input.c
+++ b/src/input.c
@@ -71,16 +71,27 @@ void handleDevInput() {
     if      (IsMouseButtonReleased(MOUSE_BUTTON_RIGHT))     CameraPanningStop();
     if      (IsMouseButtonDown(MOUSE_BUTTON_MIDDLE))        CameraPanningReset();
 
+
+    // Entitiy selection
     if (STATE->isEditorEnabled && IsKeyDown(KEY_LEFT_CONTROL) && IsMouseButtonDown(MOUSE_BUTTON_LEFT)) {
         EditorSelectEntities(mousePosInScene);
         return;
     }
     else if (STATE->isEditorEnabled && IsMouseButtonDown(MOUSE_BUTTON_LEFT) && EDITOR_ENTITY_SELECTION) {
+
         // Actions available when entities are selected
+
+        if (STATE->editorSelectedEntity &&
+            STATE->editorSelectedEntity->type == EDITOR_ENTITY_ERASER &&
+            IsInPlayArea(mousePosInScreen))
+                    goto skip_to_button_handler;
+
         EditorSelectionCancel();
     }
 
+
     if      (!IsInPlayArea(mousePosInScreen)) return;
+
 
     if (STATE->showDebugHUD || STATE->isEditorEnabled) {
 
@@ -105,7 +116,9 @@ void handleDevInput() {
             return;
         }
 
+skip_to_button_handler:
         if (IsMouseButtonDown(MOUSE_BUTTON_LEFT)) {
+
             // TODO use a timer to not keep checking it every frame
 
             if (STATE->editorSelectedEntity == 0) return;

--- a/src/input.c
+++ b/src/input.c
@@ -75,6 +75,10 @@ void handleDevInput() {
         EditorSelectEntities(mousePosInScene);
         return;
     }
+    else if (STATE->isEditorEnabled && IsMouseButtonDown(MOUSE_BUTTON_LEFT) && EDITOR_ENTITY_SELECTION) {
+        // Actions available when entities are selected
+        EditorSelectionCancel();
+    }
 
     if      (!IsInPlayArea(mousePosInScreen)) return;
 

--- a/src/input.c
+++ b/src/input.c
@@ -71,6 +71,11 @@ void handleDevInput() {
     if      (IsMouseButtonReleased(MOUSE_BUTTON_RIGHT))     CameraPanningStop();
     if      (IsMouseButtonDown(MOUSE_BUTTON_MIDDLE))        CameraPanningReset();
 
+    if (STATE->isEditorEnabled && IsKeyDown(KEY_LEFT_CONTROL) && IsMouseButtonDown(MOUSE_BUTTON_LEFT)) {
+        EditorSelectEntities(mousePosInScene);
+        return;
+    }
+
     if      (!IsInPlayArea(mousePosInScreen)) return;
 
     if (STATE->showDebugHUD || STATE->isEditorEnabled) {

--- a/src/level/level.c
+++ b/src/level/level.c
@@ -208,6 +208,9 @@ LevelEntity *LevelEntityGetAt(Vector2 pos) {
 
 void LevelEntityRemoveAt(Vector2 pos) {
 
+    // TODO This function is a monstruosity and should be broken up
+    // in at least two others ASAP
+
     ListNode *node = LEVEL_LIST_HEAD;
     while (node != 0) {
 

--- a/src/level/level.c
+++ b/src/level/level.c
@@ -215,10 +215,7 @@ void LevelEntityRemoveAt(Vector2 pos) {
 
         if (entity->components & LEVEL_IS_PLAYER) goto next_node;
 
-        if (CheckCollisionPointRec(pos, (Rectangle) {
-                                                entity->origin.x,       entity->origin.y,
-                                                entity->hitbox.width,   entity->hitbox.height
-                                            })) {
+        if (CheckCollisionPointRec(pos, LevelEntityOriginHitbox(entity))) {
             break;
         }
 
@@ -329,4 +326,12 @@ void LevelLoadNew() {
     LEVEL_PLAYER->hitbox.y = LEVEL_PLAYER->origin.y;
 
     strcpy(STATE->loadedLevel, DEFAULT_NEW_LEVEL_NAME);
+}
+
+Rectangle LevelEntityOriginHitbox(LevelEntity *entity) {
+
+    return (Rectangle){
+        entity->origin.x, entity->origin.y,
+        entity->hitbox.width, entity->hitbox.height
+    };
 }

--- a/src/level/level.c
+++ b/src/level/level.c
@@ -43,8 +43,8 @@ static ListNode *getEntityOnScene(Vector2 pos) {
 
         if (CheckCollisionPointRec(pos, entity->hitbox)) {
 
-                return node;
-            }
+            return node;
+        }
 
         node = node->next;
     };
@@ -229,7 +229,33 @@ next_node:
 
     if (!node) return;
 
-    LevelEntityDestroy(node);
+    LevelEntity *entity = (LevelEntity *) node->item;
+
+    bool isPartOfSelection = EDITOR_ENTITY_SELECTION &&
+                                LinkedListGetNode(EDITOR_ENTITY_SELECTION->entitiesHead, entity);
+    if (isPartOfSelection) {
+
+        ListNode *selectedNode = EDITOR_ENTITY_SELECTION->entitiesHead;
+        while (selectedNode) {
+
+            ListNode *next = selectedNode->next;
+            LevelEntity *selectedEntity = (LevelEntity *) selectedNode->item;
+
+            if (selectedEntity->components & LEVEL_IS_PLAYER) goto next_selected_node;
+
+            ListNode *nodeInLevel = LinkedListGetNode(LEVEL_LIST_HEAD, selectedEntity);
+            LevelEntityDestroy(nodeInLevel);
+
+next_selected_node:
+            selectedNode = next;
+        }
+
+        EditorSelectionCancel();
+
+    } else {
+
+        LevelEntityDestroy(node);
+    }
 }
 
 void LevelTick() {

--- a/src/level/level.h
+++ b/src/level/level.h
@@ -124,6 +124,9 @@ void LevelSave();
 // Loads a new, default level
 void LevelLoadNew();
 
+// Get this entity's origin hitbox, based on the current hitbox.
+Rectangle LevelEntityOriginHitbox(LevelEntity *entity);
+
 
 void LevelPlayerInitialize(Vector2 origin);
 

--- a/src/overworld.c
+++ b/src/overworld.c
@@ -21,15 +21,6 @@ static OverworldEntity *OW_CURSOR = 0;
 static char *overworldLevelSelectedName = 0;
 
 
-static Rectangle getGridSquare(OverworldEntity *entity) {
-    return (Rectangle) {
-        entity->gridPos.x,
-        entity->gridPos.y,
-        OW_GRID.width,
-        OW_GRID.height,
-    };
-}
-
 // Updates the position for the cursor according to the tile under it
 static void updateCursorPosition() {
 
@@ -79,7 +70,7 @@ static ListNode *getEntityOnScene(Vector2 pos) {
         OverworldEntity *entity = (OverworldEntity *) node->item;
 
         if (!(entity->components & OW_IS_CURSOR) &&
-            CheckCollisionPointRec(pos, getGridSquare(entity))) {
+            CheckCollisionPointRec(pos, OverworldEntitySquare(entity))) {
 
                 return node;
             }
@@ -290,7 +281,7 @@ void OverworldTileAddOrInteract(Vector2 pos) {
 
         if (entity->components & OW_IS_CURSOR) goto next_entity;
 
-        if (!CheckCollisionRecs(testHitbox, getGridSquare(entity))) goto next_entity;
+        if (!CheckCollisionRecs(testHitbox, OverworldEntitySquare(entity))) goto next_entity;
 
         if (entity->components & OW_IS_LEVEL_DOT) {
             TraceLog(LOG_TRACE, "Couldn't place tile, collided with item component=%d, x=%.1f, y=%.1f",
@@ -374,4 +365,14 @@ void OverworldTick() {
 
 void OverworldSave() {
     PersistenceOverworldSave();
+}
+
+Rectangle OverworldEntitySquare(OverworldEntity *entity) {
+
+    return (Rectangle) {
+        entity->gridPos.x,
+        entity->gridPos.y,
+        OW_GRID.width,
+        OW_GRID.height,
+    };
 }

--- a/src/overworld.h
+++ b/src/overworld.h
@@ -76,5 +76,8 @@ void OverworldTick();
 // Saves overworld's state to persistence.
 void OverworldSave();
 
+// Returns the grid square for a given entity
+Rectangle OverworldEntitySquare(OverworldEntity *entity);
+
 
 #endif // _OVERWORLD_H_INCLUDED_

--- a/src/render.c
+++ b/src/render.c
@@ -7,6 +7,7 @@
 #include "level/level.h"
 #include "overworld.h"
 #include "camera.h"
+#include "editor.h"
 
 #pragma GCC diagnostic push 
 #pragma GCC diagnostic ignored "-Wunused-parameter"
@@ -43,6 +44,13 @@ ListNode *DEBUG_ENTITY_INFO_HEAD = 0;
 static RenderTexture2D shaderRenderTexture;
 static LevelTransitionShaderControl levelTransitionShaderControl;
 
+// Draws rectangle with scene-based position
+static void drawSceneRectangle(Rectangle rect, Color color) {
+
+    Vector2 scenePos = PosInSceneToScreen((Vector2){ rect.x, rect.y });
+    Rectangle screenRect = (Rectangle){ scenePos.x, scenePos.y, rect.width, rect.height };
+    DrawRectangleRec(screenRect, color);
+}
 
 static void drawTexture(Sprite sprite, Vector2 pos, Color tint, bool flipHorizontally) {
 
@@ -423,7 +431,32 @@ next_button:
     }
 }
 
+static void drawEditorEntitySelection() {
+
+    drawSceneRectangle(EditorSelectionGetRect(), EDITOR_SELECTION_RECT_COLOR);
+
+    ListNode *node = EDITOR_ENTITY_SELECTION->entitiesHead;
+    while (node != 0) {
+
+        if (STATE->mode == MODE_IN_LEVEL) {
+            LevelEntity *entity = (LevelEntity *) node->item;
+            drawSceneRectangle(entity->hitbox, EDITOR_SELECTION_ENTITY_COLOR);
+            drawSceneRectangle(LevelEntityOriginHitbox(entity), EDITOR_SELECTION_ENTITY_COLOR);
+        }
+        else if (STATE->mode == MODE_OVERWORLD) {
+            OverworldEntity *entity = (OverworldEntity *) node->item;
+            drawSceneRectangle(OverworldEntitySquare(entity), EDITOR_SELECTION_ENTITY_COLOR);
+        }
+
+        node = node->next;
+    }
+}
+
 static void drawEditor() {
+
+    if (EDITOR_ENTITY_SELECTION)
+        drawEditorEntitySelection();
+
 
     DrawLine(SCREEN_WIDTH,
                 0,

--- a/src/render.c
+++ b/src/render.c
@@ -433,19 +433,22 @@ next_button:
 
 static void drawEditorEntitySelection() {
 
-    drawSceneRectangle(EditorSelectionGetRect(), EDITOR_SELECTION_RECT_COLOR);
+    if (EDITOR_ENTITY_SELECTION->isSelecting)
+        drawSceneRectangle(EditorSelectionGetRect(), EDITOR_SELECTION_RECT_COLOR);
 
     ListNode *node = EDITOR_ENTITY_SELECTION->entitiesHead;
     while (node != 0) {
 
+        const Color color = EDITOR_SELECTION_ENTITY_COLOR;
+
         if (STATE->mode == MODE_IN_LEVEL) {
             LevelEntity *entity = (LevelEntity *) node->item;
-            drawSceneRectangle(entity->hitbox, EDITOR_SELECTION_ENTITY_COLOR);
-            drawSceneRectangle(LevelEntityOriginHitbox(entity), EDITOR_SELECTION_ENTITY_COLOR);
+            drawSceneRectangle(entity->hitbox, color);
+            drawSceneRectangle(LevelEntityOriginHitbox(entity), color);
         }
         else if (STATE->mode == MODE_OVERWORLD) {
             OverworldEntity *entity = (OverworldEntity *) node->item;
-            drawSceneRectangle(OverworldEntitySquare(entity), EDITOR_SELECTION_ENTITY_COLOR);
+            drawSceneRectangle(OverworldEntitySquare(entity), color);
         }
 
         node = node->next;


### PR DESCRIPTION
Hold CTRL + left click and drag the mouse to select entities.

If the eraser is selected, you can keep using it, including to delete whole selections.*

Click again to cancel the selection.

***

***Note:** The workings of the selection together with the eraser are NOT intuitive (bugs listed below). The implementation using goto in editor.c is at fault here. Still, for now we're prioritizing code simplicity over powerful tooling -- if this becomes a problem alongside the development I can revisit this.

1- Selecting the eraser with a selection made cancels the selection, when it shouldn't. 
2- The selection keeps existing even if you click elsewhere in the screen with the eraser selected, when it should be canceled.