### PR TITLE
Renamed stuff related to the editor's buttons

### DIFF
--- a/src/core.h
+++ b/src/core.h
@@ -14,7 +14,7 @@
 #define FLOOR_DEATH_HEIGHT 800 // Below this y in level the player dies
 
 
-struct EditorEntityItem;
+struct EditorEntityButton;
 struct OverworldEntity;
 
 typedef struct Dimensions {
@@ -35,7 +35,8 @@ typedef struct GameState {
 
     bool isPaused;
 
-    struct EditorEntityItem *editorSelectedEntity;
+    // What entity button is currently selected in the editor
+    struct EditorEntityButton *editorButtonToggled;
     bool isEditorEnabled;
 
     struct OverworldEntity *tileUnderCursor;

--- a/src/editor.h
+++ b/src/editor.h
@@ -43,6 +43,7 @@
 
 
 typedef enum { 
+
     EDITOR_ENTITY_ERASER,
 
     // In level
@@ -56,21 +57,22 @@ typedef enum {
     EDITOR_ENTITY_STRAIGHT,
     EDITOR_ENTITY_PATH_JOIN,
     EDITOR_ENTITY_PATH_IN_L,
+    
 } EditorEntityType;
 
 typedef enum {
     EDITOR_INTERACTION_CLICK,
     EDITOR_INTERACTION_HOLD
-} EditorItemInteraction;
+} EditorInteractionType;
 
-typedef struct EditorEntityItem {
+typedef struct EditorEntityButton {
+
     EditorEntityType type;
-
-    void (*handler)(Vector2);
-
     Sprite sprite;
-    EditorItemInteraction interaction;
-} EditorEntityItem;
+    void (*handler)(Vector2); // Receives the click scene pos
+    EditorInteractionType interactionType;
+
+} EditorEntityButton;
 
 
 typedef enum { 
@@ -78,13 +80,13 @@ typedef enum {
     EDITOR_CONTROL_NEW_LEVEL
 } EditorControlType;
 
-typedef struct EditorControlItem {
-    EditorControlType type;
+typedef struct EditorControlButton {
 
+    EditorControlType type;
+    char *label;
     void (*handler)();
 
-    char *label;
-} EditorControlItem;
+} EditorControlButton;
 
 
 // A selection of entities in the screen by a cursor.
@@ -123,6 +125,8 @@ void EditorDisable();
 void EditorEnabledToggle();
 
 void EditorTick();
+
+void EditorEntityButtonSelect(EditorEntityButton *item);
 
 // Handles the selection of entities by a cursor dragging.
 void EditorSelectEntities(Vector2 cursorPos);

--- a/src/input.c
+++ b/src/input.c
@@ -81,8 +81,8 @@ void handleDevInput() {
 
         // Actions available when entities are selected
 
-        if (STATE->editorSelectedEntity &&
-            STATE->editorSelectedEntity->type == EDITOR_ENTITY_ERASER &&
+        if (STATE->editorButtonToggled &&
+            STATE->editorButtonToggled->type == EDITOR_ENTITY_ERASER &&
             IsInPlayArea(mousePosInScreen))
                     goto skip_to_button_handler;
 
@@ -121,21 +121,21 @@ skip_to_button_handler:
 
             // TODO use a timer to not keep checking it every frame
 
-            if (STATE->editorSelectedEntity == 0) return;
+            if (!STATE->editorButtonToggled) return;
 
-            if (STATE->editorSelectedEntity->handler == 0) {
+            if (!STATE->editorButtonToggled->handler) {
                 if (IsMouseButtonPressed(MOUSE_BUTTON_LEFT))
                     TraceLog(LOG_WARNING, "No code to handle selected editor entity.");
                 return;
             }
 
             // so holding doesn't keep activating the item
-            if (STATE->editorSelectedEntity->interaction == EDITOR_INTERACTION_CLICK &&
+            if (STATE->editorButtonToggled->interactionType == EDITOR_INTERACTION_CLICK &&
                 !IsMouseButtonPressed(MOUSE_BUTTON_LEFT))
                     return;
 
 
-            STATE->editorSelectedEntity->handler(mousePosInScene);
+            STATE->editorButtonToggled->handler(mousePosInScene);
             return;
         }
     }
@@ -183,9 +183,4 @@ void InputHandle() {
     else if (STATE->mode == MODE_OVERWORLD) {
         handleOverworldInput();
     }
-}
-
-void InputEditorEntitySelect(EditorEntityItem *item) {
-
-    STATE->editorSelectedEntity = item;
 }

--- a/src/input.h
+++ b/src/input.h
@@ -5,7 +5,6 @@
 #include "editor.h"
 
 void InputHandle();
-void InputEditorEntitySelect(EditorEntityItem *item);
 
 
 #endif // _INPUT_H_INCLUDED_

--- a/src/overworld.c
+++ b/src/overworld.c
@@ -318,8 +318,10 @@ next_entity:
 
     OverworldTileType typeToAdd;
 
-    // This is highly gambiarra, the selected item should be received as a param
-    switch (STATE->editorSelectedEntity->type) {
+    // This is highly gambiarra, the tile type should be informed to this function somehow,
+    // instead of having to read here which editor button is toggled
+    switch (STATE->editorButtonToggled->type) {
+        
         case EDITOR_ENTITY_LEVEL_DOT:
             typeToAdd = OW_LEVEL_DOT; break;
         case EDITOR_ENTITY_STRAIGHT:
@@ -331,7 +333,7 @@ next_entity:
         default:
             TraceLog(LOG_ERROR,
                         "Couldn't find Overworld Tile Type for Editor Item Type %d.",
-                        STATE->editorSelectedEntity->type);
+                        STATE->editorButtonToggled->type);
             return;
     }
 

--- a/src/render.c
+++ b/src/render.c
@@ -359,7 +359,7 @@ next_node:
 }
 
 // Render editor buttons of game entities
-static void drawEditorButtonsEntities() {
+static void drawEditorEntityButtons() {
 
     DrawRectangle(EDITOR_ENTITIES_AREA.x,
                     EDITOR_ENTITIES_AREA.y,
@@ -367,16 +367,16 @@ static void drawEditorButtonsEntities() {
                     EDITOR_ENTITIES_AREA.height,
                     EDITOR_BG_COLOR);
 
-    int editorButtonsRendered = 0;
+    int renderedCount = 0;
     ListNode *node = EDITOR_ENTITIES_HEAD;
 
     while (node != 0) {
 
-        EditorEntityItem *item = (EditorEntityItem *) node->item;
+        EditorEntityButton *item = (EditorEntityButton *) node->item;
 
-        bool isItemSelected = STATE->editorSelectedEntity == item;
+        bool isItemSelected = STATE->editorButtonToggled == item;
 
-        Rectangle buttonRect = EditorEntityButtonRect(editorButtonsRendered);
+        Rectangle buttonRect = EditorEntityButtonRect(renderedCount);
 
         GuiToggleSprite(
             buttonRect,
@@ -385,16 +385,16 @@ static void drawEditorButtonsEntities() {
             &isItemSelected
         );
 
-        if (isItemSelected) InputEditorEntitySelect(item);
+        if (isItemSelected) EditorEntityButtonSelect(item);
 
-        editorButtonsRendered++;
+        renderedCount++;
 
         node = node->next;
     }
 }
 
 // Render editor buttons related to control functions
-static void drawEditorButtonsControl() {
+static void drawEditorControlButtons() {
 
     DrawRectangle(EDITOR_CONTROL_AREA.x,
                     EDITOR_CONTROL_AREA.y,
@@ -402,20 +402,20 @@ static void drawEditorButtonsControl() {
                     EDITOR_CONTROL_AREA.height,
                     EDITOR_BG_COLOR);
 
-    int editorButtonsRendered = 0;
+    int renderedCount = 0;
     ListNode *node = EDITOR_CONTROL_HEAD;
 
     while (node != 0) {
 
-        EditorControlItem *item = (EditorControlItem *) node->item;
+        EditorControlButton *item = (EditorControlButton *) node->item;
 
-        Rectangle buttonRect = EditorControlButtonRect(editorButtonsRendered);
+        Rectangle buttonRect = EditorControlButtonRect(renderedCount);
 
         if (GuiButton(buttonRect, item->label)) {
 
             if (!item->handler) {
                 TraceLog(LOG_WARNING, "No handler to editor control button #%d, '%s'.",
-                            editorButtonsRendered, item->label);
+                            renderedCount, item->label);
                 goto next_button;
             }
 
@@ -425,7 +425,7 @@ static void drawEditorButtonsControl() {
         }
 
 next_button:
-        editorButtonsRendered++;
+        renderedCount++;
 
         node = node->next;
     }
@@ -467,7 +467,7 @@ static void drawEditor() {
                 SCREEN_HEIGHT,
                 RAYWHITE);
 
-    drawEditorButtonsEntities();
+    drawEditorEntityButtons();
 
     DrawLine(SCREEN_WIDTH,
                 EDITOR_ENTITIES_AREA.height,
@@ -475,7 +475,7 @@ static void drawEditor() {
                 EDITOR_ENTITIES_AREA.height,
                 RAYWHITE); // Separator
 
-    drawEditorButtonsControl();
+    drawEditorControlButtons();
 }
 
 static void drawLevelTransitionShader() {


### PR DESCRIPTION
This is because having the GameState field that controls which editor entity button is selected named "editorSelectedEntity" started being confusing after the addition of entity selection in the editor.