### PR TITLE
Move selected entities on editor

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -71,6 +71,7 @@ void SystemsInitialize() {
     AssetsInitialize();
     GameStateInitialize();
     CameraInitialize();
+    EditorInitialize();
     RenderInitialize();
 }
 

--- a/src/core.c
+++ b/src/core.c
@@ -178,3 +178,12 @@ Vector2 DistanceFromGrid(Vector2 coords, Dimensions grid) {
         distanceFromGrid(coords.y, grid.height)
     };
 }
+
+Vector2 RectangleGetPos(Rectangle rect) {
+    return (Vector2){ rect.x, rect.y };
+}
+
+void RectangleSetPos(Rectangle *rect, Vector2 pos) {
+    rect->x = pos.x;
+    rect->y = pos.y;
+}

--- a/src/core.h
+++ b/src/core.h
@@ -22,6 +22,11 @@ typedef struct Dimensions {
     float height;
 } Dimensions;
 
+typedef struct Trajectory {
+    Vector2 start;
+    Vector2 end;
+} Trajectory;
+
 typedef enum GameMode {
     MODE_IN_LEVEL,
     MODE_OVERWORLD

--- a/src/core.h
+++ b/src/core.h
@@ -99,5 +99,11 @@ Vector2 SnapToGrid(Vector2 coords, Dimensions grid);
 // The distance between a point and the closest (bottom-right) point of a grid.
 Vector2 DistanceFromGrid(Vector2 coords, Dimensions grid);
 
+// Returns the x and y of a rectangle
+Vector2 RectangleGetPos(Rectangle rect);
+
+// Sets the x and y of a rectangle according to a Vector
+void RectangleSetPos(Rectangle *rect, Vector2 pos);
+
 
 #endif // _CORE_H_INCLUDED_

--- a/src/editor.c
+++ b/src/editor.c
@@ -129,7 +129,63 @@ next_entity:
 
 void selectEntitiesApplyMove() {
 
-    // TODO
+    // Searches for collision 
+    ListNode *node = EDITOR_STATE->selectedEntities;
+    while (node) {
+
+        switch (STATE->mode) {
+
+        case MODE_IN_LEVEL: {
+            LevelEntity *entity = (LevelEntity *) node->item;
+            Rectangle hitbox = entity->hitbox;
+            Vector2 pos = EditorEntitySelectionCalcMove(RectangleGetPos(hitbox));
+            RectangleSetPos(&hitbox, pos);
+            if (LevelCheckCollisionWithAnything(hitbox))
+                return;
+            break;
+        }
+
+        case MODE_OVERWORLD: {
+            OverworldEntity *entity = (OverworldEntity *) node->item;
+            Rectangle hitbox = OverworldEntitySquare(entity);
+            Vector2 pos = EditorEntitySelectionCalcMove(RectangleGetPos(hitbox));
+            RectangleSetPos(&hitbox, pos);
+            if (OverworldCheckCollisionWithAnyTile(hitbox))
+                return;
+            break;
+        }
+
+        }
+        node = node->next;
+    }
+
+    // Apply move
+    Vector2 newPos;
+    node = EDITOR_STATE->selectedEntities;
+
+    while (node) {
+        
+        switch (STATE->mode) {
+
+        case MODE_IN_LEVEL: {
+            LevelEntity *entity = (LevelEntity *) node->item;
+            newPos = EditorEntitySelectionCalcMove(RectangleGetPos(entity->hitbox));
+            RectangleSetPos(&entity->hitbox, newPos);
+            entity->origin = EditorEntitySelectionCalcMove(entity->origin);
+            break;
+        }
+
+        case MODE_OVERWORLD: {
+            OverworldEntity *entity = (OverworldEntity *) node->item;
+            entity->gridPos = EditorEntitySelectionCalcMove(entity->gridPos);
+            break;
+        }
+
+        }
+        node = node->next;
+    }
+
+    EditorSelectionCancel();
 
     TraceLog(LOG_TRACE, "Editor applied selected entities displacement.");
 }

--- a/src/editor.h
+++ b/src/editor.h
@@ -96,7 +96,10 @@ typedef struct EditorState {
     bool        selectedEntitiesThisFrame;
     Trajectory  entitySelectionCoords;
     ListNode *  selectedEntities;
+
+    // Moving selected entities
     bool        isMovingSelectedEntities;
+    bool        movedEntitiesThisFrame;
     Trajectory  selectedEntitiesDisplacement;
 
 } EditorState;
@@ -141,8 +144,9 @@ void EditorSelectEntities(Vector2 cursorPos);
 // Cancels the selection of entities.
 void EditorSelectionCancel();
 
-// Moves a cluster of selected entities.
-void EditorSelectedEntitiesMove(Vector2 cursorPos);
+// Moves a cluster of selected entities, if the cursor is above one.
+// Otherwise, returns false;
+bool EditorSelectedEntitiesMove(Vector2 cursorPos);
 
 // Calculates and returns an editor entity buttons' coordinates,
 // alongside its dimensions

--- a/src/editor.h
+++ b/src/editor.h
@@ -41,6 +41,10 @@
 
 #define EDITOR_SELECTION_ENTITY_COLOR   (Color){ BLUE.r, BLUE.g, BLUE.b, 128 }
 
+// How transparent, compared to the original, the ghost of the
+// entities being moved will be
+#define EDITOR_SELECTION_MOVE_TRANSPARENCY      128
+
 
 typedef enum { 
 
@@ -100,7 +104,7 @@ typedef struct EditorState {
     // Moving selected entities
     bool        isMovingSelectedEntities;
     bool        movedEntitiesThisFrame;
-    Trajectory  selectedEntitiesDisplacement;
+    Trajectory  selectedEntitiesMoveCoords;
 
 } EditorState;
 
@@ -159,6 +163,10 @@ Rectangle EditorControlButtonRect(int buttonNumber);
 // Converts current editor's entity selection coordinates from
 // a trajectory to a rectangle (with positive dimensions, so missing direction).
 Rectangle EditorSelectionGetRect();
+
+// Calculates an entity's position according to the current move coordinates for
+// the selected entities, as well as parameters like the current game mode's grid.
+Vector2 EditorEntitySelectionCalcMove(Vector2 hitbox);
 
 
 #endif // _EDITOR_H_INCLUDED_

--- a/src/editor.h
+++ b/src/editor.h
@@ -89,16 +89,20 @@ typedef struct EditorControlButton {
 } EditorControlButton;
 
 
-// A selection of entities in the screen by a cursor.
-typedef struct EditorSelection {
+typedef struct EditorState {
 
-    Vector2 origin;
-    Vector2 current;
-    bool isSelecting;
-    ListNode *entitiesHead;
+    // Entity selection
+    bool        isSelectingEntities;
+    bool        selectedEntitiesThisFrame;
+    Trajectory  entitySelectionCoords;
+    ListNode *  selectedEntities;
+    bool        isMovingSelectedEntities;
+    Trajectory  selectedEntitiesDisplacement;
 
-} EditorSelection;
+} EditorState;
 
+
+// TODO move loaded editor buttons to EditorState
 
 // The head of the linked list of all the loaded editor entity itens
 extern ListNode *EDITOR_ENTITIES_HEAD;
@@ -106,9 +110,12 @@ extern ListNode *EDITOR_ENTITIES_HEAD;
 // The head of the linked list of all the loaded editor control itens
 extern ListNode *EDITOR_CONTROL_HEAD;
 
-// Selection of entities in the screen by a cursor, if a selection is hapenning.
-extern EditorSelection *EDITOR_ENTITY_SELECTION;
+extern EditorState *EDITOR_STATE;
 
+
+void EditorInitialize();
+
+void EditorStateReset();
 
 // Destroy any existing editor itens and then loads the items
 // for the current game mode
@@ -134,6 +141,9 @@ void EditorSelectEntities(Vector2 cursorPos);
 // Cancels the selection of entities.
 void EditorSelectionCancel();
 
+// Moves a cluster of selected entities.
+void EditorSelectedEntitiesMove(Vector2 cursorPos);
+
 // Calculates and returns an editor entity buttons' coordinates,
 // alongside its dimensions
 Rectangle EditorEntityButtonRect(int buttonNumber);
@@ -142,7 +152,9 @@ Rectangle EditorEntityButtonRect(int buttonNumber);
 // alongside its dimensions
 Rectangle EditorControlButtonRect(int buttonNumber);
 
-// Gets the rectangle for the current editor's entity selection.
+// Converts current editor's entity selection coordinates from
+// a trajectory to a rectangle (with positive dimensions, so missing direction).
 Rectangle EditorSelectionGetRect();
+
 
 #endif // _EDITOR_H_INCLUDED_

--- a/src/input.c
+++ b/src/input.c
@@ -85,13 +85,11 @@ void handleDevInput() {
 
         // Actions available when entities are selected
 
-        // if (CheckCollisionPointRec(mousePosInScene, EditorSelectionGetRect())) {
-        //     EditorSelectedEntitiesMove(mousePosInScene);
-        // }
-
         if (STATE->editorButtonToggled &&
             STATE->editorButtonToggled->type == EDITOR_ENTITY_ERASER)
                     goto skip_to_button_handler;
+
+        if (EditorSelectedEntitiesMove(mousePosInScene)) return;
 
         EditorSelectionCancel();
     }

--- a/src/input.c
+++ b/src/input.c
@@ -79,17 +79,23 @@ void handleDevInput() {
         EditorSelectEntities(mousePosInScene);
         return;
     }
-    else if (STATE->isEditorEnabled && IsMouseButtonDown(MOUSE_BUTTON_LEFT) && EDITOR_ENTITY_SELECTION) {
+    else if (STATE->isEditorEnabled && IsMouseButtonDown(MOUSE_BUTTON_LEFT) && EDITOR_STATE->selectedEntities) {
+
+        if (!IsInPlayArea(mousePosInScreen)) goto skip_selected_entities_actions;
 
         // Actions available when entities are selected
 
+        // if (CheckCollisionPointRec(mousePosInScene, EditorSelectionGetRect())) {
+        //     EditorSelectedEntitiesMove(mousePosInScene);
+        // }
+
         if (STATE->editorButtonToggled &&
-            STATE->editorButtonToggled->type == EDITOR_ENTITY_ERASER &&
-            IsInPlayArea(mousePosInScreen))
+            STATE->editorButtonToggled->type == EDITOR_ENTITY_ERASER)
                     goto skip_to_button_handler;
 
         EditorSelectionCancel();
     }
+skip_selected_entities_actions:
 
 
     if      (!IsInPlayArea(mousePosInScreen)) return;

--- a/src/level/block.c
+++ b/src/level/block.c
@@ -42,7 +42,7 @@ void LevelBlockCheckAndAdd(Vector2 origin) {
     origin = SnapToGrid(origin, LEVEL_GRID);
 
     Rectangle hitbox = SpriteHitboxFromEdge(BlockSprite, origin);
-    if (LevelCheckCollisionWithAnyEntityOrOrigin(hitbox)) return;
+    if (LevelCheckCollisionWithAnything(hitbox)) return;
     
     LevelBlockAdd(origin);
 }
@@ -52,7 +52,7 @@ void LevelAcidCheckAndAdd(Vector2 origin) {
     origin = SnapToGrid(origin, LEVEL_GRID);
 
     Rectangle hitbox = SpriteHitboxFromEdge(AcidSprite, origin);
-    if (LevelCheckCollisionWithAnyEntityOrOrigin(hitbox)) return;
+    if (LevelCheckCollisionWithAnything(hitbox)) return;
     
     LevelAcidAdd(origin);
 }

--- a/src/level/enemy.c
+++ b/src/level/enemy.c
@@ -32,7 +32,7 @@ void LevelEnemyCheckAndAdd(Vector2 origin) {
 
     Rectangle hitbox = SpriteHitboxFromMiddle(EnemySprite, origin);
 
-    if (LevelCheckCollisionWithAnyEntityOrOrigin(hitbox)) {
+    if (LevelCheckCollisionWithAnything(hitbox)) {
         TraceLog(LOG_DEBUG, "Couldn't add enemy to level, collision with entity.");
         return;
     }

--- a/src/level/level.c
+++ b/src/level/level.c
@@ -234,11 +234,10 @@ next_node:
 
     LevelEntity *entity = (LevelEntity *) node->item;
 
-    bool isPartOfSelection = EDITOR_ENTITY_SELECTION &&
-                                LinkedListGetNode(EDITOR_ENTITY_SELECTION->entitiesHead, entity);
+    bool isPartOfSelection = LinkedListGetNode(EDITOR_STATE->selectedEntities, entity);
     if (isPartOfSelection) {
 
-        ListNode *selectedNode = EDITOR_ENTITY_SELECTION->entitiesHead;
+        ListNode *selectedNode = EDITOR_STATE->selectedEntities;
         while (selectedNode) {
 
             ListNode *next = selectedNode->next;

--- a/src/level/level.c
+++ b/src/level/level.c
@@ -129,7 +129,7 @@ void LevelExitCheckAndAdd(Vector2 pos) {
     
     Rectangle hitbox = SpriteHitboxFromMiddle(LevelEndOrbSprite, pos);
 
-    if (LevelCheckCollisionWithAnyEntityOrOrigin(hitbox)) {
+    if (LevelCheckCollisionWithAnything(hitbox)) {
         TraceLog(LOG_DEBUG, "Couldn't add level exit, collision with entity.");
         return;
     }
@@ -316,7 +316,7 @@ bool LevelCheckCollisionWithAnyEntity(Rectangle hitbox) {
     return false;
 }
 
-bool LevelCheckCollisionWithAnyEntityOrOrigin(Rectangle hitbox) {
+bool LevelCheckCollisionWithAnything(Rectangle hitbox) {
 
     ListNode *node = LEVEL_LIST_HEAD;
 

--- a/src/level/level.h
+++ b/src/level/level.h
@@ -173,7 +173,7 @@ bool LevelCheckCollisionWithAnyEntity(Rectangle hitbox);
 
 // Checks for collision between a rectangle and any 
 // living entity in the level, including their origins.
-bool LevelCheckCollisionWithAnyEntityOrOrigin(Rectangle hitbox);
+bool LevelCheckCollisionWithAnything(Rectangle hitbox);
 
 void LevelEnemyKill(LevelEntity *entity);
 

--- a/src/level/player.c
+++ b/src/level/player.c
@@ -32,7 +32,7 @@
 // JUMP_BUFFER_BACKWARDS_SIZE for when the player is gliding.
 // The player is falling slower, and it feels jarring to have  
 // a smaller Y window where the backwards jump buffer works.
-#define JUMP_BUFFER_BACKWARDS_SIZE_GLIDING  0.12f
+#define JUMP_BUFFER_BACKWARDS_SIZE_GLIDING  0.20f
 
 // How many seconds after having left the ground the jump command
 // still works

--- a/src/overworld.c
+++ b/src/overworld.c
@@ -355,11 +355,10 @@ void OverworldTileRemoveAt(Vector2 pos) {
 
     OverworldEntity *entity = (OverworldEntity *) node->item;
 
-    bool isPartOfSelection = EDITOR_ENTITY_SELECTION &&
-                                LinkedListGetNode(EDITOR_ENTITY_SELECTION->entitiesHead, entity);
+    bool isPartOfSelection = LinkedListGetNode(EDITOR_STATE->selectedEntities, entity);
     if (isPartOfSelection) {
 
-        ListNode *node = EDITOR_ENTITY_SELECTION->entitiesHead;
+        ListNode *node = EDITOR_STATE->selectedEntities;
         while (node) {
             ListNode *next = node->next;
             ListNode *nodeInOW = LinkedListGetNode(OW_LIST_HEAD, (OverworldEntity *) node->item);

--- a/src/overworld.c
+++ b/src/overworld.c
@@ -147,17 +147,17 @@ OverworldEntity *OverworldTileAdd(Vector2 pos, OverworldTileType type, int degre
         newTile->sprite = LevelDotSprite;
         break;
     case OW_STRAIGHT_PATH:
-        newTile->components = OW_IS_PATH;
+        newTile->components = OW_IS_PATH + OW_IS_ROTATABLE;
         newTile->sprite = PathTileStraightSprite;
         SpriteRotate(&newTile->sprite, degrees);
         break;
     case OW_JOIN_PATH:
-        newTile->components = OW_IS_PATH;
+        newTile->components = OW_IS_PATH + OW_IS_ROTATABLE;
         newTile->sprite = PathTileJoinSprite;
         SpriteRotate(&newTile->sprite, degrees);
         break;
     case OW_PATH_IN_L:
-        newTile->components = OW_IS_PATH;
+        newTile->components = OW_IS_PATH + OW_IS_ROTATABLE;
         newTile->sprite = PathTileInLSprite;
         SpriteRotate(&newTile->sprite, degrees);
         break;
@@ -285,24 +285,21 @@ next_entity:
 void OverworldTileAddOrInteract(Vector2 pos) {
 
     pos = SnapToGrid(pos, OW_GRID);
+
     Rectangle testHitbox = (Rectangle){ pos.x,
                                     pos.y,
                                     OW_GRID.width,
                                     OW_GRID.width };
 
-    ListNode *node = OW_LIST_HEAD;
-
     OverworldEntity *entity = OverworldCheckCollisionWithAnyTile(testHitbox);
 
     if (entity) {
 
-        if (entity->components & OW_IS_CURSOR) return;
-
-        if (entity->components & OW_IS_LEVEL_DOT) {
-        TraceLog(LOG_TRACE, "Couldn't place tile, collided with item component=%d, x=%.1f, y=%.1f",
-                        entity->components, entity->gridPos.x, entity->gridPos.y);
-        return;
-    }
+        if (!(entity->components & OW_IS_ROTATABLE)) {
+            TraceLog(LOG_TRACE, "Couldn't place tile, collided with item component=%d, x=%.1f, y=%.1f",
+                            entity->components, entity->gridPos.x, entity->gridPos.y);
+            return;
+        }
 
         // Interacting
         SpriteRotate(&entity->sprite, 90);

--- a/src/overworld.h
+++ b/src/overworld.h
@@ -30,6 +30,7 @@ typedef enum OverworldEntityComponent {
     OW_IS_CURSOR            = 1,
     OW_IS_LEVEL_DOT         = 2,
     OW_IS_PATH              = 4,
+    OW_IS_ROTATABLE         = 8,
 } OverworldEntityComponent;
 
 typedef struct OverworldEntity {

--- a/src/overworld.h
+++ b/src/overworld.h
@@ -71,6 +71,10 @@ void OverworldTileAddOrInteract(Vector2 pos);
 // Removes tile from overworld and destroys it, if present and if allowed.
 void OverworldTileRemoveAt(Vector2 pos);
 
+// Checks for collision between a hitbox and any tile in the overworld.
+// Returns the collided entity, or 0 if none.
+OverworldEntity *OverworldCheckCollisionWithAnyTile(Rectangle hitbox);
+
 void OverworldTick();
 
 // Saves overworld's state to persistence.

--- a/src/render.c
+++ b/src/render.c
@@ -166,6 +166,21 @@ static void drawOverworldEntity(OverworldEntity *entity) {
     drawTexture(entity->sprite, (Vector2){ pos.x, pos.y }, WHITE, false);
 }
 
+// Draws the ghost of an editor's selected entity being moved
+static void drawOverworldEntityMoveGhost(OverworldEntity *entity) {
+
+    Vector2 pos = EditorEntitySelectionCalcMove((Vector2){
+                                                    entity->gridPos.x,
+                                                    entity->gridPos.y });
+
+    pos = PosInSceneToScreen(pos);
+
+    Color color = (Color) { WHITE.r, WHITE.g, WHITE.b,
+                            EDITOR_SELECTION_MOVE_TRANSPARENCY };
+
+    drawTexture(entity->sprite, pos, color, false);
+}
+
 static void drawLevelEntity(LevelEntity *entity) {
 
     Vector2 pos = PosInSceneToScreen((Vector2){
@@ -175,6 +190,20 @@ static void drawLevelEntity(LevelEntity *entity) {
     drawTexture(entity->sprite, (Vector2){ pos.x, pos.y }, WHITE, !entity->isFacingRight);
 }
 
+// Draws the ghost of an editor's selected entity being moved
+static void drawLevelEntityMoveGhost(LevelEntity *entity) {
+
+    Vector2 pos = EditorEntitySelectionCalcMove((Vector2){
+                                                    entity->hitbox.x,
+                                                    entity->hitbox.y });
+
+    pos = PosInSceneToScreen(pos);
+
+    Color color = (Color) { WHITE.r, WHITE.g, WHITE.b,
+                            EDITOR_SELECTION_MOVE_TRANSPARENCY };
+
+    drawTexture(entity->sprite, pos, color, !entity->isFacingRight);
+}
 
 static void drawLevelEntityOrigin(LevelEntity *entity) {
 
@@ -444,13 +473,27 @@ static void drawEditorEntitySelection() {
         const Color color = EDITOR_SELECTION_ENTITY_COLOR;
 
         if (STATE->mode == MODE_IN_LEVEL) {
+
             LevelEntity *entity = (LevelEntity *) node->item;
-            drawSceneRectangle(entity->hitbox, color);
-            drawSceneRectangle(LevelEntityOriginHitbox(entity), color);
+
+            if (EDITOR_STATE->isMovingSelectedEntities) {
+                drawLevelEntityMoveGhost(entity);
+            } else {
+                drawSceneRectangle(entity->hitbox, color);
+                drawSceneRectangle(LevelEntityOriginHitbox(entity), color);
+            }
+
         }
         else if (STATE->mode == MODE_OVERWORLD) {
+
             OverworldEntity *entity = (OverworldEntity *) node->item;
-            drawSceneRectangle(OverworldEntitySquare(entity), color);
+
+            if (EDITOR_STATE->isMovingSelectedEntities) {
+                drawOverworldEntityMoveGhost(entity);
+            } else {
+                drawSceneRectangle(OverworldEntitySquare(entity), color);
+            }
+            
         }
 
         node = node->next;

--- a/src/render.c
+++ b/src/render.c
@@ -435,10 +435,10 @@ next_button:
 
 static void drawEditorEntitySelection() {
 
-    if (EDITOR_ENTITY_SELECTION->isSelecting)
+    if (EDITOR_STATE->isSelectingEntities)
         drawSceneRectangle(EditorSelectionGetRect(), EDITOR_SELECTION_RECT_COLOR);
 
-    ListNode *node = EDITOR_ENTITY_SELECTION->entitiesHead;
+    ListNode *node = EDITOR_STATE->selectedEntities;
     while (node != 0) {
 
         const Color color = EDITOR_SELECTION_ENTITY_COLOR;
@@ -459,8 +459,7 @@ static void drawEditorEntitySelection() {
 
 static void drawEditor() {
 
-    if (EDITOR_ENTITY_SELECTION)
-        drawEditorEntitySelection();
+    drawEditorEntitySelection();
 
 
     DrawLine(SCREEN_WIDTH,


### PR DESCRIPTION
Being able to drag and move selected entities demand more state related to the entities selection. So it was created an EditorState and all the selection state was moved to it.

When you drag over a a cluster of selected entities, a ghost of their potential new positions is shown as the player moves the mouse.

When you released it, the editor check for collisions in the level or overworld using a generic API and, if there's no collision, updates the position (and origin) of each selected entity to the trajectory of the mouse drag movement.