### PR TITLE
Enemy turns around if colliding with level geometry

### DIFF
--- a/src/level/enemy.c
+++ b/src/level/enemy.c
@@ -89,6 +89,25 @@ void LevelEnemyTick(ListNode *enemyNode) {
 
     if (enemy->isFacingRight) enemy->hitbox.x += ENEMY_SPEED_DEFAULT;
     else enemy->hitbox.x -= ENEMY_SPEED_DEFAULT;
+
+    ListNode *node = LEVEL_LIST_HEAD;
+    while (node) {
+
+        LevelEntity *entity = (LevelEntity *) node->item;
+
+        if (entity == enemy) goto next_node;
+
+        if (entity->components & LEVEL_IS_SCENARIO &&
+            CheckCollisionRecs(entity->hitbox, enemy->hitbox)) {
+
+                enemy->isFacingRight = !enemy->isFacingRight;
+
+                return;
+        }
+
+next_node:
+        node = node->next;
+    }
 }
 
 void LevelEnemyKill(LevelEntity *entity) {


### PR DESCRIPTION
Introduced here each enemy looping over every level entity checking for collision with level geometry (based on the LEVEL_IS_SCENARIO component).

This represents another step closer to the moment where the whole entity system will need to be rethought -- only looping through entities close to the screen would go a long way, but the linked list has got to go, probably in favor of a data structure that allows fast access according to the nodes position in a bidimensional grid.