### PR TITLE
Player can't acquire running horizontal speed in the air if started jumping with normal speed

### DIFF
--- a/src/input.c
+++ b/src/input.c
@@ -32,9 +32,9 @@ void handleInLevelInput() {
     if      (IsKeyDown(KEY_Z))              PlayerStartRunning();
     else                                    PlayerStopRunning();
 
-    if      (IsKeyDown(KEY_RIGHT))          PlayerMoveHorizontal(PLAYER_MOVEMENT_RIGHT);
-    else if (IsKeyDown(KEY_LEFT))           PlayerMoveHorizontal(PLAYER_MOVEMENT_LEFT);
-    else                                    PlayerMoveHorizontal(PLAYER_MOVEMENT_STOP);
+    if      (IsKeyDown(KEY_RIGHT))          PlayerMoveHorizontal(PLAYER_DIRECTION_RIGHT);
+    else if (IsKeyDown(KEY_LEFT))           PlayerMoveHorizontal(PLAYER_DIRECTION_LEFT);
+    else                                    PlayerMoveHorizontal(PLAYER_DIRECTION_STOP);
 
     if      (IsKeyPressed(KEY_X))           PlayerJump();
 

--- a/src/level/player.h
+++ b/src/level/player.h
@@ -12,11 +12,11 @@ typedef enum PlayerMovementSpeed {
     PLAYER_MOVEMENT_RUNNING
 } PlayerMovementSpeed;
 
-typedef enum PlayerHorizontalMovementType {
-    PLAYER_MOVEMENT_STOP,
-    PLAYER_MOVEMENT_LEFT,
-    PLAYER_MOVEMENT_RIGHT
-} PlayerHorizontalMovementType;
+typedef enum PlayerHorizontalDirection {
+    PLAYER_DIRECTION_STOP,
+    PLAYER_DIRECTION_LEFT,
+    PLAYER_DIRECTION_RIGHT
+} PlayerHorizontalDirection;
 
 typedef enum PlayerMode {
     PLAYER_MODE_DEFAULT,
@@ -37,11 +37,17 @@ typedef struct PlayerState {
     // If the player is on mode 'GLIDE' and is actively gliding
     bool isGliding;
 
+    // The player's horizontal movement's direction
+    PlayerHorizontalDirection xDirection;
+
     float yVelocity;
     float yVelocityTarget;
     float xVelocity;
 
     PlayerMovementSpeed speed;
+
+    // The speed of the current jump (if jumping)
+    PlayerMovementSpeed jumpSpeed;
 
     PlayerMode mode;
 
@@ -68,7 +74,7 @@ void PlayerCheckAndSetPos(Vector2 pos);
 
 void PlayerSetMode(PlayerMode mode);
 
-void PlayerMoveHorizontal(PlayerHorizontalMovementType direction);
+void PlayerMoveHorizontal(PlayerHorizontalDirection direction);
 
 void PlayerStartRunning();
 


### PR DESCRIPTION
Previously the holding of the 'run' button switched the dimension of the horizontal velocity on the spot. But it felt weird to press the button while in the air and have the player acquire an horizontal momentum he didn't have before. (The vertical velocity has a slightly more realistic system already, so no problems here.)

Now it was added a flag in the player state to keep track of the speed the player had when he started the jump. If it was normal speed, then he can't get faster than normal horizontal velocity until he lands.

Note that if you start jump while running, stop running (or even stop altogether) while in the air, and then resume running before landing, you will acquire your horizontal velocity back. This is for design reasons: I don't want to punish the player with lost momentum for doing cool maneuvers in the air.

The horizontal velocity will eventually have to be force-based so we can have inertia.
***

This horizontal velocity control was moved to the tick function, where it belongs (this function's getting pretty big though).

Some player constants were renamed for consistency and clarity.