### PR TITLE
Created the 'debug' module

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,6 +20,7 @@
         "block.h": "c",
         "powerups.h": "c",
         "player.h": "c",
-        "*.m": "c"
+        "*.m": "c",
+        "debug.h": "c"
     }
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ set(CMAKE_C_STANDARD 11) # required by raylib
 
 add_executable(${PROJECT_NAME} src/game.c src/level/player.c src/linked_list.c src/level/enemy.c
     src/level/level.c src/camera.c src/core.c src/render.c src/input.c src/editor.c src/assets.c
-    src/overworld.c src/level/block.c src/files.c src/persistence.c src/level/powerups.c)
+    src/overworld.c src/level/block.c src/files.c src/persistence.c src/level/powerups.c src/debug.c)
 
 set(raylib_VERBOSE 1)
 target_link_libraries(${PROJECT_NAME} raylib)

--- a/src/core.c
+++ b/src/core.c
@@ -8,6 +8,7 @@
 #include "level/level.h"
 #include "editor.h"
 #include "render.h"
+#include "debug.h"
 
 
 GameState *GAME_STATE = 0;

--- a/src/core.c
+++ b/src/core.c
@@ -131,7 +131,7 @@ void MouseCursorEnable() {
 void DebugHudToggle() {
 
     if (GAME_STATE->showDebugHUD) {
-        RenderDebugEntityStopAll();
+        DebugEntityStopAll();
         DebugHudDisable();
     }
     else {

--- a/src/debug.c
+++ b/src/debug.c
@@ -1,0 +1,37 @@
+#include <raylib.h>
+
+#include "debug.h"
+#include "level/level.h"
+#include "linked_list.h"
+
+
+ListNode *DEBUG_ENTITY_INFO_HEAD = 0;
+
+
+void DebugEntityToggle(LevelEntity *entity) {
+    
+    if (!entity) return;
+
+    ListNode *entitysNode = LinkedListGetNode(DEBUG_ENTITY_INFO_HEAD, entity);
+
+    if (entitysNode) {
+        LinkedListRemoveNode(&DEBUG_ENTITY_INFO_HEAD, entitysNode);
+        TraceLog(LOG_TRACE, "Debug entity info removed entity;");
+    } else {
+        LinkedListAdd(&DEBUG_ENTITY_INFO_HEAD, entity);
+        TraceLog(LOG_TRACE, "Debug entity info added entity;");
+    }
+}
+
+void DebugEntityStop(LevelEntity *entity) {
+    ListNode *entitysNode = LinkedListGetNode(DEBUG_ENTITY_INFO_HEAD, entity);
+    if (entitysNode) {
+        LinkedListRemoveNode(&DEBUG_ENTITY_INFO_HEAD, entitysNode);
+        TraceLog(LOG_TRACE, "Debug entity info stopped showing entity.");
+    }
+}
+
+void DebugEntityStopAll() {
+    LinkedListRemoveAll(&DEBUG_ENTITY_INFO_HEAD);
+    TraceLog(LOG_TRACE, "Debug entity info stopped showing all entities.");
+}

--- a/src/debug.h
+++ b/src/debug.h
@@ -1,0 +1,22 @@
+#ifndef _DEBUG_H_INCLUDED_
+#define _DEBUG_H_INCLUDED_
+
+
+#include "linked_list.h"
+#include "level/level.h"
+
+
+extern ListNode *DEBUG_ENTITY_INFO_HEAD;
+
+
+// Shows info about entity, or stop showing if it's there already.
+void DebugEntityToggle(LevelEntity *entity);
+
+// Stops showing info about an entity. If it's not showing already, does nothing.
+void DebugEntityStop(LevelEntity *entity);
+
+// Stops showing info about all entities.
+void DebugEntityStopAll();
+
+
+#endif // _DEBUG_H_INCLUDED_

--- a/src/input.c
+++ b/src/input.c
@@ -11,6 +11,7 @@
 #include "persistence.h"
 #include "render.h"
 #include "editor.h"
+#include "debug.h"
 
 
 void handleInLevelInput() {
@@ -113,7 +114,7 @@ skip_selected_entities_actions:
     if (GAME_STATE->showDebugHUD) {
 
         if  (IsMouseButtonPressed(MOUSE_BUTTON_LEFT)) {
-            RenderDebugEntityToggle(LevelEntityGetAt(mousePosInScene));
+            DebugEntityToggle(LevelEntityGetAt(mousePosInScene));
             return;
         }
     }

--- a/src/level/enemy.c
+++ b/src/level/enemy.c
@@ -2,7 +2,8 @@
 
 #include "enemy.h"
 #include "level.h"
-#include "../render.h"
+#include "../debug.h"
+
 
 #define ENEMY_SPEED_DEFAULT 4.0f
 #define ENEMY_FALL_RATE 7.0f

--- a/src/level/enemy.c
+++ b/src/level/enemy.c
@@ -113,7 +113,7 @@ void EnemyKill(LevelEntity *entity) {
 
     entity->isDead = true;
 
-    RenderDebugEntityStop(entity);
+    DebugEntityStop(entity);
 
     TraceLog(LOG_TRACE, "Enemy died.");
 }

--- a/src/level/level.c
+++ b/src/level/level.c
@@ -9,6 +9,7 @@
 #include "../render.h"
 #include "../editor.h"
 #include "../overworld.h"
+#include "../debug.h"
 
 
 // The difference between the y of the hitbox and the ground to be considered "on the ground"

--- a/src/level/level.c
+++ b/src/level/level.c
@@ -192,7 +192,7 @@ void LevelGoToOverworld() {
         SpritePosMiddlePoint(
             (Vector2){PLAYER_ENTITY->hitbox.x, PLAYER_ENTITY->hitbox.y}, PLAYER_ENTITY->sprite), true);
 
-    RenderDebugEntityStopAll();
+    DebugEntityStopAll();
 
     LEVEL_STATE->concludedAgo = GetTime();
 }
@@ -272,7 +272,7 @@ void LevelEntityDestroy(ListNode *node) {
 
     if (entity == LEVEL_STATE->checkpoint) LEVEL_STATE->checkpoint = 0;
 
-    RenderDebugEntityStop(entity);
+    DebugEntityStop(entity);
 
     LinkedListDestroyNode(&LEVEL_STATE->listHead, node);
 

--- a/src/linked_list.c
+++ b/src/linked_list.c
@@ -58,8 +58,6 @@ ListNode *LinkedListGetNode(ListNode *head, void *item) {
         head = head->next;
     }
 
-    TraceLog(LOG_TRACE, "Linked list get node returning %x.", head);
-
     return head;
 }
 

--- a/src/overworld.c
+++ b/src/overworld.c
@@ -293,7 +293,7 @@ void OverworldTileAddOrInteract(Vector2 pos) {
     Rectangle testHitbox = (Rectangle){ pos.x,
                                     pos.y,
                                     OW_GRID.width,
-                                    OW_GRID.width };
+                                    OW_GRID.height };
 
     OverworldEntity *entity = OverworldCheckCollisionWithAnyTile(testHitbox);
 

--- a/src/render.c
+++ b/src/render.c
@@ -8,6 +8,7 @@
 #include "overworld.h"
 #include "camera.h"
 #include "editor.h"
+#include "debug.h"
 
 #pragma GCC diagnostic push 
 #pragma GCC diagnostic ignored "-Wunused-parameter"
@@ -36,8 +37,6 @@ typedef struct LevelTransitionShaderControl {
 
 
 ListNode *SYS_MESSAGES_HEAD = 0;
-
-ListNode *DEBUG_ENTITY_INFO_HEAD = 0;
 
 
 // Texture covering the whole screen, used to render shaders
@@ -636,30 +635,4 @@ void RenderLevelTransitionEffectStart(Vector2 sceneFocusPoint, bool isClose) {
 
     // Fix for how GLSL works
     levelTransitionShaderControl.focusPoint.y = GetScreenHeight() - levelTransitionShaderControl.focusPoint.y;
-}
-
-void RenderDebugEntityToggle(LevelEntity *entity) {
-    
-    ListNode *entitysNode = LinkedListGetNode(DEBUG_ENTITY_INFO_HEAD, entity);
-
-    if (entitysNode) {
-        LinkedListRemoveNode(&DEBUG_ENTITY_INFO_HEAD, entitysNode);
-        TraceLog(LOG_TRACE, "Debug entity info removed entity;");
-    } else {
-        LinkedListAdd(&DEBUG_ENTITY_INFO_HEAD, entity);
-        TraceLog(LOG_TRACE, "Debug entity info added entity;");
-    }
-}
-
-void RenderDebugEntityStop(LevelEntity *entity) {
-    ListNode *entitysNode = LinkedListGetNode(DEBUG_ENTITY_INFO_HEAD, entity);
-    if (entitysNode) {
-        LinkedListRemoveNode(&DEBUG_ENTITY_INFO_HEAD, entitysNode);
-        TraceLog(LOG_TRACE, "Debug entity info stopped showing entity.");
-    }
-}
-
-void RenderDebugEntityStopAll() {
-    LinkedListRemoveAll(&DEBUG_ENTITY_INFO_HEAD);
-    TraceLog(LOG_TRACE, "Debug entity info stopped showing all entities.");
 }

--- a/src/render.h
+++ b/src/render.h
@@ -26,14 +26,5 @@ void RenderPrintSysMessage(char *msg);
 */
 void RenderLevelTransitionEffectStart(Vector2 sceneFocusPont, bool isClose);
 
-// Shows info about entity, or stop showing if it's there already.
-void RenderDebugEntityToggle(LevelEntity *entity);
-
-// Stops showing info about an entity. If it's not showing already, does nothing.
-void RenderDebugEntityStop(LevelEntity *entity);
-
-// Stops showing info about all entities.
-void RenderDebugEntityStopAll();
-
 
 #endif // _RENDER_H_INCLUDED_


### PR DESCRIPTION
To solve ticket #157 it would be very handy to have entity debugging for overworld itens.

When implementing so it became evident that debugging logic should have its own module. The render module already was managing stuff that wasn't about rendering, and so was the input when it had to search the level for an entity to ask render to show debug info on it.
