### PR TITLE
Overworld entity debug

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,6 +21,8 @@
         "powerups.h": "c",
         "player.h": "c",
         "*.m": "c",
-        "debug.h": "c"
+        "debug.h": "c",
+        "level.h": "c",
+        "linked_list.h": "c"
     }
 }

--- a/src/core.c
+++ b/src/core.c
@@ -172,3 +172,8 @@ void RectangleSetPos(Rectangle *rect, Vector2 pos) {
     rect->x = pos.x;
     rect->y = pos.y;
 }
+
+void RectangleSetDimensions(Rectangle *rect, Dimensions dims) {
+    rect->width = dims.width;
+    rect->height = dims.height;
+}

--- a/src/core.h
+++ b/src/core.h
@@ -83,5 +83,8 @@ Vector2 RectangleGetPos(Rectangle rect);
 // Sets the x and y of a rectangle according to a Vector
 void RectangleSetPos(Rectangle *rect, Vector2 pos);
 
+// Sets the width and height of a rectangle according to a Dimensions
+void RectangleSetDimensions(Rectangle *rect, Dimensions dims);
+
 
 #endif // _CORE_H_INCLUDED_

--- a/src/debug.c
+++ b/src/debug.c
@@ -8,7 +8,13 @@
 ListNode *DEBUG_ENTITY_INFO_HEAD = 0;
 
 
-void DebugEntityToggle(LevelEntity *entity) {
+void DebugEntityToggle(Vector2 pos) {
+
+    void *entity;
+    if (GAME_STATE->mode == MODE_IN_LEVEL)
+        entity = LevelEntityGetAt(pos);
+    else
+        return;
     
     if (!entity) return;
 
@@ -24,7 +30,9 @@ void DebugEntityToggle(LevelEntity *entity) {
 }
 
 void DebugEntityStop(LevelEntity *entity) {
+    
     ListNode *entitysNode = LinkedListGetNode(DEBUG_ENTITY_INFO_HEAD, entity);
+
     if (entitysNode) {
         LinkedListRemoveNode(&DEBUG_ENTITY_INFO_HEAD, entitysNode);
         TraceLog(LOG_TRACE, "Debug entity info stopped showing entity.");
@@ -32,6 +40,8 @@ void DebugEntityStop(LevelEntity *entity) {
 }
 
 void DebugEntityStopAll() {
+
     LinkedListRemoveAll(&DEBUG_ENTITY_INFO_HEAD);
+
     TraceLog(LOG_TRACE, "Debug entity info stopped showing all entities.");
 }

--- a/src/debug.c
+++ b/src/debug.c
@@ -2,6 +2,7 @@
 
 #include "debug.h"
 #include "level/level.h"
+#include "overworld.h"
 #include "linked_list.h"
 
 
@@ -11,10 +12,14 @@ ListNode *DEBUG_ENTITY_INFO_HEAD = 0;
 void DebugEntityToggle(Vector2 pos) {
 
     void *entity;
-    if (GAME_STATE->mode == MODE_IN_LEVEL)
-        entity = LevelEntityGetAt(pos);
-    else
+    switch (GAME_STATE->mode) {
+    case MODE_IN_LEVEL:
+        entity = LevelEntityGetAt(pos); break;
+    case MODE_OVERWORLD:
+        entity = OverworldEntityGetAt(pos); break;
+    default:
         return;
+    }
     
     if (!entity) return;
 
@@ -22,20 +27,20 @@ void DebugEntityToggle(Vector2 pos) {
 
     if (entitysNode) {
         LinkedListRemoveNode(&DEBUG_ENTITY_INFO_HEAD, entitysNode);
-        TraceLog(LOG_TRACE, "Debug entity info removed entity;");
+        TraceLog(LOG_TRACE, "Debug entity info disabled entity.");
     } else {
         LinkedListAdd(&DEBUG_ENTITY_INFO_HEAD, entity);
-        TraceLog(LOG_TRACE, "Debug entity info added entity;");
+        TraceLog(LOG_TRACE, "Debug entity info enabled entity.");
     }
 }
 
-void DebugEntityStop(LevelEntity *entity) {
+void DebugEntityStop(void *entity) {
     
     ListNode *entitysNode = LinkedListGetNode(DEBUG_ENTITY_INFO_HEAD, entity);
 
     if (entitysNode) {
         LinkedListRemoveNode(&DEBUG_ENTITY_INFO_HEAD, entitysNode);
-        TraceLog(LOG_TRACE, "Debug entity info stopped showing entity.");
+        TraceLog(LOG_TRACE, "Debug entity info disabled entity.");
     }
 }
 
@@ -43,5 +48,5 @@ void DebugEntityStopAll() {
 
     LinkedListRemoveAll(&DEBUG_ENTITY_INFO_HEAD);
 
-    TraceLog(LOG_TRACE, "Debug entity info stopped showing all entities.");
+    TraceLog(LOG_TRACE, "Debug entity info disabled all entities.");
 }

--- a/src/debug.h
+++ b/src/debug.h
@@ -2,6 +2,8 @@
 #define _DEBUG_H_INCLUDED_
 
 
+#include <raylib.h>
+
 #include "linked_list.h"
 #include "level/level.h"
 
@@ -9,8 +11,9 @@
 extern ListNode *DEBUG_ENTITY_INFO_HEAD;
 
 
-// Shows info about entity, or stop showing if it's there already.
-void DebugEntityToggle(LevelEntity *entity);
+// Searches for entity at pos and, if it finds one, shows
+// debug info about it, or stop showing if it's enabled already.
+void DebugEntityToggle(Vector2 pos);
 
 // Stops showing info about an entity. If it's not showing already, does nothing.
 void DebugEntityStop(LevelEntity *entity);

--- a/src/debug.h
+++ b/src/debug.h
@@ -12,11 +12,11 @@ extern ListNode *DEBUG_ENTITY_INFO_HEAD;
 
 
 // Searches for entity at pos and, if it finds one, shows
-// debug info about it, or stop showing if it's enabled already.
+// debug info about it, or stops showing if it's enabled already.
 void DebugEntityToggle(Vector2 pos);
 
 // Stops showing info about an entity. If it's not showing already, does nothing.
-void DebugEntityStop(LevelEntity *entity);
+void DebugEntityStop(void *entity);
 
 // Stops showing info about all entities.
 void DebugEntityStopAll();

--- a/src/input.c
+++ b/src/input.c
@@ -114,7 +114,7 @@ skip_selected_entities_actions:
     if (GAME_STATE->showDebugHUD) {
 
         if  (IsMouseButtonPressed(MOUSE_BUTTON_LEFT)) {
-            DebugEntityToggle(LevelEntityGetAt(mousePosInScene));
+            DebugEntityToggle(mousePosInScene);
             return;
         }
     }

--- a/src/level/level.c
+++ b/src/level/level.c
@@ -64,7 +64,7 @@ void leaveLevel() {
 
 // Searches for an entity in a given position
 // and returns its node, or 0 if not found.
-static ListNode *getEntityOnScene(Vector2 pos) {
+static ListNode *getEntityNodeAtPos(Vector2 pos) {
 
     ListNode *node = LEVEL_STATE->listHead;
 
@@ -282,7 +282,7 @@ void LevelEntityDestroy(ListNode *node) {
 
 LevelEntity *LevelEntityGetAt(Vector2 pos) {
 
-    ListNode *node = getEntityOnScene(pos);
+    ListNode *node = getEntityNodeAtPos(pos);
 
     if (!node) return 0;
 

--- a/src/overworld.h
+++ b/src/overworld.h
@@ -71,6 +71,9 @@ void OverworldLoad();
 // and returns it.
 OverworldEntity *OverworldTileAdd(Vector2 pos, OverworldTileType type, int degrees);
 
+// Searches for an overworld entity at a given position
+OverworldEntity *OverworldEntityGetAt(Vector2 pos);
+
 // If the current tile contains a level, starts 'go to level' routine and select it
 void OverworldLevelSelect();
 

--- a/src/render.c
+++ b/src/render.c
@@ -366,7 +366,8 @@ static void drawDebugHud() {
 
     ListNode *node = DEBUG_ENTITY_INFO_HEAD;
     while (node != 0) {
-        LevelEntity *entity = (LevelEntity *) node->item;
+        void *entity = node->item;
+        Rectangle hitbox;
         ListNode *nextNode = node->next;
 
         if (!entity) { // Destroyed
@@ -375,21 +376,32 @@ static void drawDebugHud() {
             goto next_node;
         }
 
-        Vector2 pos = PosInSceneToScreen((Vector2) {
-                                            entity->hitbox.x,
-                                            entity->hitbox.y
-                                        });
+        switch (GAME_STATE->mode) {
+        case MODE_IN_LEVEL:
+            hitbox = ((LevelEntity *) entity)->hitbox;
+            break;
 
-        DrawRectangle(pos.x, pos.y,
-                entity->hitbox.width, entity->hitbox.height, (Color){ GREEN.r, GREEN.g, GREEN.b, 128 });
-        DrawRectangleLines(pos.x, pos.y,
-                entity->hitbox.width, entity->hitbox.height, GREEN);
+        case MODE_OVERWORLD:
+            RectangleSetPos(&hitbox, ((OverworldEntity *) entity)->gridPos);
+            RectangleSetDimensions(&hitbox, OW_GRID);
+            break;
+
+        default:
+            return;
+        }
+
+        Vector2 screenPos = PosInSceneToScreen(RectangleGetPos(hitbox));
+
+        DrawRectangle(screenPos.x, screenPos.y,
+                hitbox.width, hitbox.height, (Color){ GREEN.r, GREEN.g, GREEN.b, 128 });
+        DrawRectangleLines(screenPos.x, screenPos.y,
+                hitbox.width, hitbox.height, GREEN);
 
         char buffer[500];
         sprintf(buffer, "X=%.1f\nY=%.1f",
-                    entity->hitbox.x,
-                    entity->hitbox.y);
-        DrawText(buffer, pos.x, pos.y, 25, WHITE);
+                    hitbox.x,
+                    hitbox.y);
+        DrawText(buffer, screenPos.x, screenPos.y, 25, WHITE);
 
 next_node:
         node = nextNode;


### PR DESCRIPTION
Useful for ticket #157.

It was created a function, part of the overworld API, to search for overworld entities. This pushed the creation of a function to set rects' dimensions (part of the core).

The debug module was modified to correctly add the entity to the list, and the render function to retrieve the entity from the list.