### PR TITLE
Sound module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ set(CMAKE_CXX_STANDARD 20)
 add_executable(${PROJECT_NAME} src/game.cpp src/level/player.cpp src/linked_list.cpp src/level/enemy.cpp
     src/level/level.cpp src/camera.cpp src/core.cpp src/render.cpp src/input.cpp src/editor.cpp src/assets.cpp
     src/overworld.cpp src/level/block.cpp src/files.cpp src/persistence.cpp src/level/powerups.cpp src/debug.cpp
-    src/text_bank.cpp)
+    src/text_bank.cpp src/sounds.cpp)
 
 set(raylib_VERBOSE 1)
 target_link_libraries(${PROJECT_NAME} raylib)

--- a/src/assets.cpp
+++ b/src/assets.cpp
@@ -4,9 +4,9 @@
 #include "assets.hpp"
 
 
-Sounds *SOUNDS = 0;
+struct SoundBank *SOUNDS = 0;
 
-Sprites *SPRITES = 0;
+struct SpriteBank *SPRITES = 0;
 
 // Shaders
 Shader ShaderLevelTransition;
@@ -30,8 +30,8 @@ static inline Sprite doubleSizeSprite(std::string texturePath) {
 
 void AssetsInitialize() {
 
-    SPRITES = (Sprites *) MemAlloc(sizeof(Sprites));
-    Sprites *sp = SPRITES;
+    SPRITES = (SpriteBank *) MemAlloc(sizeof(SpriteBank));
+    SpriteBank *sp = SPRITES;
 
     // Editor
     sp->Eraser = doubleSizeSprite("../assets/eraser_1.png");
@@ -61,8 +61,8 @@ void AssetsInitialize() {
 
 
 
-    SOUNDS = (Sounds *) MemAlloc(sizeof(Sounds));
-    Sounds *sn = SOUNDS;
+    SOUNDS = (SoundBank *) MemAlloc(sizeof(SoundBank));
+    SoundBank *sn = SOUNDS;
 
     sn->Jump = LoadSound("../assets/sounds/jump.ogg");
     SetSoundVolume(sn->Jump, 0.5f);

--- a/src/assets.hpp
+++ b/src/assets.hpp
@@ -13,7 +13,7 @@ typedef struct Sprite {
     int rotation;
 } Sprite;
 
-typedef struct Sprites {
+struct SpriteBank {
 
     // TODO make it a hashmap
 
@@ -43,18 +43,18 @@ typedef struct Sprites {
     Sprite Nightclub;
     Sprite BGHouse;
 
-} Sprites;
+};
 
-typedef struct Sounds {
+struct SoundBank {
 
     Sound Jump;
 
-} Sounds;
+};
 
 
-extern Sprites *SPRITES;
+extern struct SpriteBank *SPRITES;
 
-extern Sounds *SOUNDS;
+extern struct SoundBank *SOUNDS;
 
 // Shaders
 extern Shader ShaderLevelTransition;

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -11,6 +11,7 @@
 #include "debug.hpp"
 #include "text_bank.hpp"
 #include "input.hpp"
+#include "sounds.hpp"
 
 
 GameState *GAME_STATE = 0;
@@ -89,6 +90,7 @@ void SystemsInitialize() {
     LevelInitialize();
     RenderInitialize();
     TextBank::InitializeAndLoad();
+    Sounds::Initialize();
 }
 
 void GameUpdate() {

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -12,6 +12,7 @@
 #include "render.hpp"
 #include "editor.hpp"
 #include "debug.hpp"
+#include "sounds.hpp"
 
 
 namespace Input {
@@ -69,6 +70,7 @@ void handleDevInput() {
     if      (IsKeyPressed(KEY_F1))          { EditorEnabledToggle(); return; }
     if      (IsKeyPressed(KEY_F2))          DebugHudToggle();
     if      (IsKeyPressed(KEY_F3))          GAME_STATE->showDebugGrid = !GAME_STATE->showDebugGrid;
+    if      (IsKeyPressed(KEY_F6))          Sounds::Toggle();
 
 
     /* Mouse functionalities */

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -173,10 +173,7 @@ void handleDroppedFile() {
             TraceLog(LOG_INFO, "Dot on x=%.1f, y=%.1f associated with level %s.",
                         OW_STATE->tileUnderCursor->gridPos.x, OW_STATE->tileUnderCursor->gridPos.y, levelName);
             
-            char *sysMsg = (char *) MemAlloc(sizeof(char) * SYS_MSG_BUFFER_SIZE);
-            sprintf(sysMsg, "Associada fase %s", levelName);
-            RenderPrintSysMessage(sysMsg);
-            MemFree(sysMsg);
+            RenderPrintSysMessage("Associada fase " + std::string(levelName));
         }
     }
 

--- a/src/level/level.cpp
+++ b/src/level/level.cpp
@@ -172,7 +172,7 @@ void createTextboxFromIdInput(Vector2 pos, std::string input) {
         id = std::stoi(input);
     }
     catch (std::invalid_argument &e) {
-        RenderPrintSysMessage((char *) "ID inválido");
+        RenderPrintSysMessage("ID inválido");
         TraceLog(LOG_DEBUG, "Textbox ID input invalid: %s.", input.c_str());
         return; // does nothing
     }
@@ -337,7 +337,7 @@ void LevelTextboxCheckAndAdd(Vector2 pos) {
         }
     );
 
-    RenderPrintSysMessage((char *) "Insira o ID do texto");
+    RenderPrintSysMessage("Insira o ID do texto");
     Input::GetTextInput(callback);
 }
 

--- a/src/level/player.cpp
+++ b/src/level/player.cpp
@@ -8,6 +8,7 @@
 #include "enemy.hpp"
 #include "../camera.hpp"
 #include "../render.hpp"
+#include "../sounds.hpp"
 
 
 // What % of the player's height is upperbody, for hitboxes
@@ -278,7 +279,7 @@ void PlayerTick() {
         pState->yVelocity = jumpStartVelocity();
         pState->yVelocityTarget = 0.0f;
         pState->jumpSpeed = pState->speed;
-        PlaySound(SOUNDS->Jump);
+        Sounds::Play(SOUNDS->Jump);
 
         // Player hit enemy
         // -- this check is for the case the player jumps off the enemy,

--- a/src/level/player.cpp
+++ b/src/level/player.cpp
@@ -152,7 +152,7 @@ void PlayerCheckAndSetOrigin(Vector2 pos) {
     if (LevelCheckCollisionWithAnyEntity(hitbox)) {
         TraceLog(LOG_DEBUG,
             "Player's origin couldn't be set at pos x=%.1f, y=%.1f; would collide with a different entity.", pos.x, pos.y);
-        RenderPrintSysMessage((char *) "Origem iria colidir.");
+        RenderPrintSysMessage("Origem iria colidir.");
         return;
     }
 
@@ -170,7 +170,7 @@ void PlayerCheckAndSetPos(Vector2 pos) {
     if (LevelCheckCollisionWithAnyEntity(hitbox)) {
         TraceLog(LOG_DEBUG,
             "Player couldn't be set at pos x=%.1f, y=%.1f; would collide with a different entity.", pos.x, pos.y);
-        RenderPrintSysMessage((char *) "Jogador iria colidir.");
+        RenderPrintSysMessage("Jogador iria colidir.");
         return;
     }
     
@@ -497,7 +497,7 @@ void PlayerSetCheckpoint() {
     }
 
     if (LEVEL_STATE->checkpointsLeft < 1) {
-        RenderPrintSysMessage((char *) "Sem checkpoints disponíveis.");
+        RenderPrintSysMessage("Sem checkpoints disponíveis.");
         return;
     }
 

--- a/src/level/player.cpp
+++ b/src/level/player.cpp
@@ -510,10 +510,7 @@ void PlayerSetCheckpoint() {
     pos.y += PLAYER_ENTITY->hitbox.height / 2;
     LEVEL_STATE->checkpoint = LevelCheckpointAdd(pos);
 
-    LEVEL_STATE->checkpointsLeft--;
-    char checkpointMsg[50];
-    sprintf(checkpointMsg, "Checkpoints disponívels: %d", LEVEL_STATE->checkpointsLeft);
-    RenderPrintSysMessage(checkpointMsg);
+    RenderPrintSysMessage("Checkpoints disponívels: " + std::to_string(--LEVEL_STATE->checkpointsLeft));
 
     TraceLog(LOG_DEBUG, "Player set checkpoint at x=%.1f, y=%.1f.", pos.x, pos.y);
 }

--- a/src/persistence.cpp
+++ b/src/persistence.cpp
@@ -111,10 +111,10 @@ skip_entity:
 
     if (FileSave(levelPath, filedata)) {
         TraceLog(LOG_INFO, "Level saved: %s.", levelName);
-        RenderPrintSysMessage((char *) "Fase salva.");
+        RenderPrintSysMessage("Fase salva.");
     } else {
         TraceLog(LOG_ERROR, "Could not save level %s.", levelName);
-        RenderPrintSysMessage((char *) "Erro salvando fase.");
+        RenderPrintSysMessage("Erro salvando fase.");
     }
 
     MemFree(data);
@@ -132,7 +132,7 @@ bool PersistenceLevelLoad(char *levelName) {
 
     if (!filedata.itemCount) {
         TraceLog(LOG_ERROR, "Could not load level %s.", levelName);
-        RenderPrintSysMessage((char *) "Erro carregando fase.");
+        RenderPrintSysMessage("Erro carregando fase.");
         return false;
     }
 
@@ -199,14 +199,14 @@ bool PersistenceGetDroppedLevelName(char *nameBuffer) {
         strcmp(GetFileName(fileDir), PERSISTENCE_DIR_NAME) != 0) {
 
             TraceLog(LOG_ERROR, "Dropped file is not on 'levels' directory.");
-            RenderPrintSysMessage((char *) "Arquivo não é parte do jogo");
+            RenderPrintSysMessage("Arquivo não é parte do jogo");
             goto return_result;
     }
 
     if (strcmp(GetFileExtension(filePath), LEVEL_FILE_EXTENSION) != 0) {
         TraceLog(LOG_ERROR, "Dropped file extension is not %s. Ignoring it",
                     LEVEL_FILE_EXTENSION);
-        RenderPrintSysMessage((char *) "Arquivo não é fase");
+        RenderPrintSysMessage("Arquivo não é fase");
         goto return_result;
     }
 
@@ -215,7 +215,7 @@ bool PersistenceGetDroppedLevelName(char *nameBuffer) {
 
             TraceLog(LOG_ERROR, "Dropped file has invalid level name %s.",
                         fileName);
-            RenderPrintSysMessage((char *) "Nome de fase proibido");
+            RenderPrintSysMessage("Nome de fase proibido");
             goto return_result;
     }
 
@@ -274,10 +274,10 @@ skip_entity:
 
     if (FileSave(filePath, filedata)) {
         TraceLog(LOG_INFO, "Overworld saved.");
-        RenderPrintSysMessage((char *) "Mundo salvo.");
+        RenderPrintSysMessage("Mundo salvo.");
     } else {
         TraceLog(LOG_ERROR, "Could not save overworld.");
-        RenderPrintSysMessage((char *) "Erro salvando mundo.");
+        RenderPrintSysMessage("Erro salvando mundo.");
     }
 
     MemFree(data);
@@ -295,7 +295,7 @@ bool PersistenceOverworldLoad() {
 
     if (!fileData.itemCount) {
         TraceLog(LOG_ERROR, "Could not overworld.");
-        RenderPrintSysMessage((char *) "Erro carregando mundo.");
+        RenderPrintSysMessage("Erro carregando mundo.");
         return false;
     }
 

--- a/src/render.cpp
+++ b/src/render.cpp
@@ -669,6 +669,11 @@ void RenderPrintSysMessage(char *msg) {
     TraceLog(LOG_TRACE, "Added sys message to list: '%s'.", msg);
 }
 
+void RenderPrintSysMessage(const std::string &msg) {
+
+    RenderPrintSysMessage((char *) msg.c_str());
+}
+
 void RenderLevelTransitionEffectStart(Vector2 sceneFocusPoint, bool isClose) {
 
     levelTransitionShaderControl.timer = GetTime();

--- a/src/render.cpp
+++ b/src/render.cpp
@@ -655,10 +655,12 @@ void RenderResizeWindow(int width, int height) {
     SetWindowSize(width, height);
 }
 
-void RenderPrintSysMessage(char *msg) {
+void RenderPrintSysMessage(const std::string &msg) {
+
+    // TODO move the whole SysMessage system to C++ strings
 
     char *msgCopy = (char *) MemAlloc(sizeof(char) * SYS_MSG_BUFFER_SIZE);
-    strcpy(msgCopy, msg); 
+    strcpy(msgCopy, msg.c_str()); 
 
     SysMessage *newMsg = (SysMessage *) MemAlloc(sizeof(SysMessage));
     newMsg->msg = msgCopy;
@@ -667,11 +669,6 @@ void RenderPrintSysMessage(char *msg) {
     LinkedListAdd(&SYS_MESSAGES_HEAD, newMsg);
 
     TraceLog(LOG_TRACE, "Added sys message to list: '%s'.", msg);
-}
-
-void RenderPrintSysMessage(const std::string &msg) {
-
-    RenderPrintSysMessage((char *) msg.c_str());
 }
 
 void RenderLevelTransitionEffectStart(Vector2 sceneFocusPoint, bool isClose) {

--- a/src/render.hpp
+++ b/src/render.hpp
@@ -1,6 +1,8 @@
 #ifndef _RENDER_H_INCLUDED_
 #define _RENDER_H_INCLUDED_
 
+#include "string"
+
 #include "level/level.hpp"
 
 
@@ -17,6 +19,9 @@ void RenderResizeWindow(int width, int height);
 
 // Prints a system message in the screen
 void RenderPrintSysMessage(char *msg);
+
+// Prints a system message in the screen
+void RenderPrintSysMessage(const std::string &msg);
 
 /*
     Starts the visual effect of transitioning from overworld to level or vice-versa.

--- a/src/render.hpp
+++ b/src/render.hpp
@@ -18,9 +18,6 @@ void Render();
 void RenderResizeWindow(int width, int height);
 
 // Prints a system message in the screen
-void RenderPrintSysMessage(char *msg);
-
-// Prints a system message in the screen
 void RenderPrintSysMessage(const std::string &msg);
 
 /*

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -1,0 +1,12 @@
+#include <raylib.h>
+
+#include "sounds.hpp"
+
+
+namespace Sounds {
+
+void Play(Sound sound) {
+    PlaySound(sound);
+}
+
+}

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -1,12 +1,40 @@
 #include <raylib.h>
 
 #include "sounds.hpp"
+#include "render.hpp"
 
 
 namespace Sounds {
 
-void Play(Sound sound) {
-    PlaySound(sound);
+
+SoundsState STATE;
+
+
+void Initialize() {
+
+    STATE = SoundsState();
+
+    TraceLog(LOG_INFO, "Sounds initialized.");
 }
+
+void Play(Sound sound) {
+
+    if (STATE.isEnabled) PlaySound(sound);
+}
+
+void Toggle() {
+
+    STATE.isEnabled = !STATE.isEnabled;
+
+    if (STATE.isEnabled) {
+        RenderPrintSysMessage("Som ligado");
+        TraceLog(LOG_INFO, "Sound enabled.");
+    }
+    else {
+        RenderPrintSysMessage("Som desligado");
+        TraceLog(LOG_INFO, "Sound disabled.");
+    }
+}
+
 
 }

--- a/src/sounds.hpp
+++ b/src/sounds.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <raylib.h>
+
+
+namespace Sounds {
+
+void Play(Sound sound);
+
+}

--- a/src/sounds.hpp
+++ b/src/sounds.hpp
@@ -5,6 +5,27 @@
 
 namespace Sounds {
 
+
+class SoundsState {
+
+public:
+    bool isEnabled;
+
+    SoundsState() {
+        isEnabled = false;
+    }
+};
+
+
+extern SoundsState STATE;
+
+
+void Initialize();
+
 void Play(Sound sound);
+
+// Toggles between sound on and off
+void Toggle();
+
 
 }


### PR DESCRIPTION
Created a sounds module. It included a toggle for turning the sound on or off, activated by pressing F6. The sound state is created with sounds off by default.

For simplicity, the RenderPrintSysMessage was modified to accept C++ strings (but it's still using char* underneath, this should change if this system ever needs a refactor).

To not collide with the new 'Sounds' namespace, the Assets' 'Sounds' and 'Assets' structs were renamed to include the word 'bank'. They also lost their typedefs because Struct types that aren't referenced often don't need typedefs -- i.e. they can be refereed to simply as 'struct X' -- to not pollute the namespaces.