### PR TITLE
Horizontal movement system clean up

### DIFF
--- a/src/input.cpp
+++ b/src/input.cpp
@@ -79,10 +79,7 @@ void handleInLevelInput() {
     if (LEVEL_STATE->isPaused || !PLAYER_ENTITY || PLAYER_ENTITY->isDead) return;
 
 
-    if (IsKeyDown(KEY_Z) || isGamepadDown(GP_X))
-        PlayerStartRunning();
-    else
-        PlayerStopRunning();
+    PlayerIsHoldingRunButton(IsKeyDown(KEY_Z) || isGamepadDown(GP_X));
 
 
     if (IsKeyDown(KEY_RIGHT) || isGamepadDown(GP_RIGHT) || isGamepadAnalogDown(ANALOG_RIGHT))

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -79,7 +79,7 @@ void handleInLevelInput() {
     if (LEVEL_STATE->isPaused || !PLAYER_ENTITY || PLAYER_ENTITY->isDead) return;
 
 
-    PlayerIsHoldingRunButton(IsKeyDown(KEY_Z) || isGamepadDown(GP_X));
+    STATE.isHoldingRun = IsKeyDown(KEY_Z) || isGamepadDown(GP_X);
 
 
     if (IsKeyDown(KEY_RIGHT) || isGamepadDown(GP_RIGHT) || isGamepadAnalogDown(ANALOG_RIGHT))

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -83,13 +83,13 @@ void handleInLevelInput() {
 
 
     if (IsKeyDown(KEY_RIGHT) || isGamepadDown(GP_RIGHT) || isGamepadAnalogDown(ANALOG_RIGHT))
-        PlayerMoveHorizontal(PLAYER_DIRECTION_RIGHT);
+        STATE.playerMoveDirection = PLAYER_DIRECTION_RIGHT; 
 
     else if (IsKeyDown(KEY_LEFT) || isGamepadDown(GP_LEFT) || isGamepadAnalogDown(ANALOG_LEFT))
-        PlayerMoveHorizontal(PLAYER_DIRECTION_LEFT);
+        STATE.playerMoveDirection = PLAYER_DIRECTION_LEFT;
 
     else
-        PlayerMoveHorizontal(PLAYER_DIRECTION_STOP);
+        STATE.playerMoveDirection = PLAYER_DIRECTION_STOP;
 
 
     if (IsKeyPressed(KEY_X) || isGamepadPressed(GP_A))

--- a/src/input.hpp
+++ b/src/input.hpp
@@ -40,6 +40,13 @@ typedef enum {
     ANALOG_DOWN = 8,
 } AnalogStickDigitalDirection;
 
+typedef enum {
+    PLAYER_DIRECTION_STOP,
+    PLAYER_DIRECTION_LEFT,
+    PLAYER_DIRECTION_RIGHT
+} PlayerMoveDirection;
+
+
 class InputState {
 
 public:
@@ -54,6 +61,7 @@ public:
     char leftStickPreviousState;
 
     bool isHoldingRun;
+    PlayerMoveDirection playerMoveDirection;
 
     InputState() {}
 };

--- a/src/input.hpp
+++ b/src/input.hpp
@@ -53,6 +53,8 @@ public:
     char leftStickCurrentState;
     char leftStickPreviousState;
 
+    bool isHoldingRun;
+
     InputState() {}
 };
 

--- a/src/level/player.cpp
+++ b/src/level/player.cpp
@@ -9,6 +9,7 @@
 #include "../camera.hpp"
 #include "../render.hpp"
 #include "../sounds.hpp"
+#include "../input.hpp"
 
 
 // What % of the player's height is upperbody, for hitboxes
@@ -61,7 +62,6 @@ static void initializePlayerState() {
     PLAYER_STATE = (PlayerState *) MemAlloc(sizeof(PlayerState));
 
     PLAYER_STATE->isAscending = false;
-    PLAYER_STATE->isHoldingRun = false;
     PLAYER_STATE->mode = PLAYER_MODE_DEFAULT;
     PLAYER_STATE->lastPressedJump = -1;
     PLAYER_STATE->lastGroundBeneath = -1;
@@ -73,7 +73,7 @@ static void initializePlayerState() {
 // propulsion of a jump
 static float jumpStartVelocity() {
 
-    if (PLAYER_STATE->isHoldingRun)
+    if (Input::STATE.isHoldingRun)
         return JUMP_START_VELOCITY_RUNNING;
     else
         return JUMP_START_VELOCITY_DEFAULT;
@@ -191,11 +191,6 @@ void PlayerMoveHorizontal(PlayerHorizontalDirection direction) {
     PLAYER_STATE->xDirection = direction;
 }
 
-void PlayerIsHoldingRunButton(bool isHolding) {
-
-    PLAYER_STATE->isHoldingRun = isHolding;
-}
-
 void PlayerJump() {
 
     PLAYER_STATE->lastPressedJump = GetTime();
@@ -223,7 +218,7 @@ void PlayerTick() {
 
     if (pState->xDirection == PLAYER_DIRECTION_STOP)
         xVelocity = 0;
-    else if (PLAYER_STATE->isHoldingRun) {
+    else if (Input::STATE.isHoldingRun) {
         // Can't move fast in the air if started jumping with normal speed
         if (pState->groundBeneath || pState->wasRunningOnJumpStart)
             xVelocity = X_VELOCITY_RUNNING;       
@@ -272,7 +267,7 @@ void PlayerTick() {
         pState->isAscending = true;
         pState->yVelocity = jumpStartVelocity();
         pState->yVelocityTarget = 0.0f;
-        pState->wasRunningOnJumpStart = pState->isHoldingRun;
+        pState->wasRunningOnJumpStart = Input::STATE.isHoldingRun;
         Sounds::Play(SOUNDS->Jump);
 
         // Player hit enemy
@@ -418,7 +413,7 @@ next_entity:
 
         if (PLAYER_STATE->mode == PLAYER_MODE_GLIDE &&
                 !PLAYER_STATE->isAscending &&
-                PLAYER_STATE->isHoldingRun) {
+                Input::STATE.isHoldingRun) {
 
             // Is gliding
             pState->yVelocity = Y_VELOCITY_GLIDING;

--- a/src/level/player.cpp
+++ b/src/level/player.cpp
@@ -61,7 +61,7 @@ static void initializePlayerState() {
     PLAYER_STATE = (PlayerState *) MemAlloc(sizeof(PlayerState));
 
     PLAYER_STATE->isAscending = false;
-    PLAYER_STATE->speed = PLAYER_MOVEMENT_DEFAULT;
+    PLAYER_STATE->isHoldingRun = false;
     PLAYER_STATE->mode = PLAYER_MODE_DEFAULT;
     PLAYER_STATE->lastPressedJump = -1;
     PLAYER_STATE->lastGroundBeneath = -1;
@@ -73,7 +73,7 @@ static void initializePlayerState() {
 // propulsion of a jump
 static float jumpStartVelocity() {
 
-    if (PLAYER_STATE->speed == PLAYER_MOVEMENT_RUNNING)
+    if (PLAYER_STATE->isHoldingRun)
         return JUMP_START_VELOCITY_RUNNING;
     else
         return JUMP_START_VELOCITY_DEFAULT;
@@ -191,14 +191,9 @@ void PlayerMoveHorizontal(PlayerHorizontalDirection direction) {
     PLAYER_STATE->xDirection = direction;
 }
 
-void PlayerStartRunning() {
+void PlayerIsHoldingRunButton(bool isHolding) {
 
-    PLAYER_STATE->speed = PLAYER_MOVEMENT_RUNNING;
-}
-
-void PlayerStopRunning() {
-
-    PLAYER_STATE->speed = PLAYER_MOVEMENT_DEFAULT;
+    PLAYER_STATE->isHoldingRun = isHolding;
 }
 
 void PlayerJump() {
@@ -228,15 +223,14 @@ void PlayerTick() {
 
     if (pState->xDirection == PLAYER_DIRECTION_STOP)
         xVelocity = 0;
-    else if (PLAYER_STATE->speed == PLAYER_MOVEMENT_RUNNING) {
+    else if (PLAYER_STATE->isHoldingRun) {
         // Can't move fast in the air if started jumping with normal speed
-        if (pState->groundBeneath || pState->jumpSpeed == PLAYER_MOVEMENT_RUNNING)
+        if (pState->groundBeneath || pState->wasRunningOnJumpStart)
             xVelocity = X_VELOCITY_RUNNING;       
         else
             xVelocity = X_VELOCITY_DEFAULT;
     }
-    else if (PLAYER_STATE->speed == PLAYER_MOVEMENT_DEFAULT)
-        xVelocity = X_VELOCITY_DEFAULT;
+    else xVelocity = X_VELOCITY_DEFAULT;
 
     if (!PLAYER_ENTITY->isFacingRight)
         xVelocity *= -1;
@@ -278,7 +272,7 @@ void PlayerTick() {
         pState->isAscending = true;
         pState->yVelocity = jumpStartVelocity();
         pState->yVelocityTarget = 0.0f;
-        pState->jumpSpeed = pState->speed;
+        pState->wasRunningOnJumpStart = pState->isHoldingRun;
         Sounds::Play(SOUNDS->Jump);
 
         // Player hit enemy
@@ -424,7 +418,7 @@ next_entity:
 
         if (PLAYER_STATE->mode == PLAYER_MODE_GLIDE &&
                 !PLAYER_STATE->isAscending &&
-                PLAYER_STATE->speed == PLAYER_MOVEMENT_RUNNING) {
+                PLAYER_STATE->isHoldingRun) {
 
             // Is gliding
             pState->yVelocity = Y_VELOCITY_GLIDING;

--- a/src/level/player.cpp
+++ b/src/level/player.cpp
@@ -186,11 +186,6 @@ void PlayerSetMode(PlayerMode mode) {
     TraceLog(LOG_DEBUG, "Player set mode to %d.", mode);
 }
 
-void PlayerMoveHorizontal(PlayerHorizontalDirection direction) {
-
-    PLAYER_STATE->xDirection = direction;
-}
-
 void PlayerJump() {
 
     PLAYER_STATE->lastPressedJump = GetTime();
@@ -208,15 +203,15 @@ void PlayerTick() {
     pState->groundBeneath = LevelGetGroundBeneath(PLAYER_ENTITY);
 
 
-    if (pState->xDirection == PLAYER_DIRECTION_RIGHT)
+    if (Input::STATE.playerMoveDirection == Input::PLAYER_DIRECTION_RIGHT)
         PLAYER_ENTITY->isFacingRight = true;
-    else if (pState->xDirection == PLAYER_DIRECTION_LEFT)
+    else if (Input::STATE.playerMoveDirection == Input::PLAYER_DIRECTION_LEFT)
         PLAYER_ENTITY->isFacingRight = false;
         
 
     float xVelocity = fabs(pState->xVelocity);
 
-    if (pState->xDirection == PLAYER_DIRECTION_STOP)
+    if (Input::STATE.playerMoveDirection == Input::PLAYER_DIRECTION_STOP)
         xVelocity = 0;
     else if (Input::STATE.isHoldingRun) {
         // Can't move fast in the air if started jumping with normal speed

--- a/src/level/player.hpp
+++ b/src/level/player.hpp
@@ -7,12 +7,6 @@
 #include "level.hpp"
 
 
-typedef enum PlayerHorizontalDirection {
-    PLAYER_DIRECTION_STOP,
-    PLAYER_DIRECTION_LEFT,
-    PLAYER_DIRECTION_RIGHT
-} PlayerHorizontalDirection;
-
 typedef enum PlayerMode {
     PLAYER_MODE_DEFAULT,
     PLAYER_MODE_GLIDE
@@ -31,9 +25,6 @@ typedef struct PlayerState {
 
     // If the player is on mode 'GLIDE' and is actively gliding
     bool isGliding;
-
-    // The player's horizontal movement's direction
-    PlayerHorizontalDirection xDirection;
 
     float yVelocity;
     float yVelocityTarget;
@@ -66,8 +57,6 @@ void PlayerCheckAndSetOrigin(Vector2 pos);
 void PlayerCheckAndSetPos(Vector2 pos);
 
 void PlayerSetMode(PlayerMode mode);
-
-void PlayerMoveHorizontal(PlayerHorizontalDirection direction);
 
 void PlayerJump();
 

--- a/src/level/player.hpp
+++ b/src/level/player.hpp
@@ -39,8 +39,6 @@ typedef struct PlayerState {
     float yVelocityTarget;
     float xVelocity;
 
-    bool isHoldingRun;
-
     // If the player is jumping, if he was running at the jump's start
     bool wasRunningOnJumpStart;
 
@@ -70,9 +68,6 @@ void PlayerCheckAndSetPos(Vector2 pos);
 void PlayerSetMode(PlayerMode mode);
 
 void PlayerMoveHorizontal(PlayerHorizontalDirection direction);
-
-// If the player is holding the run button
-void PlayerIsHoldingRunButton(bool isHolding);
 
 void PlayerJump();
 

--- a/src/level/player.hpp
+++ b/src/level/player.hpp
@@ -7,11 +7,6 @@
 #include "level.hpp"
 
 
-typedef enum PlayerMovementSpeed {
-    PLAYER_MOVEMENT_DEFAULT,
-    PLAYER_MOVEMENT_RUNNING
-} PlayerMovementSpeed;
-
 typedef enum PlayerHorizontalDirection {
     PLAYER_DIRECTION_STOP,
     PLAYER_DIRECTION_LEFT,
@@ -44,10 +39,10 @@ typedef struct PlayerState {
     float yVelocityTarget;
     float xVelocity;
 
-    PlayerMovementSpeed speed;
+    bool isHoldingRun;
 
-    // The speed of the current jump (if jumping)
-    PlayerMovementSpeed jumpSpeed;
+    // If the player is jumping, if he was running at the jump's start
+    bool wasRunningOnJumpStart;
 
     PlayerMode mode;
 
@@ -76,9 +71,8 @@ void PlayerSetMode(PlayerMode mode);
 
 void PlayerMoveHorizontal(PlayerHorizontalDirection direction);
 
-void PlayerStartRunning();
-
-void PlayerStopRunning();
+// If the player is holding the run button
+void PlayerIsHoldingRunButton(bool isHolding);
 
 void PlayerJump();
 


### PR DESCRIPTION
Em preparação à implementação da aceleração no movimento horizontal do jogador foi necessário dar uma reorganizada no código relacionado ao movimento.

Agora o player lê do estado do input se os botões de correr ou de movimento estão pressionados, ao invés de isso ser comunicado ao player e ele guardar no seu estado. Como bônus, isso permitiu dar uma limpada na interface do player.

O controle de "andando" ou "correndo" foi substituído de enum para um booleano, e as suas variáveis foram renomeadas.