### PR TITLE
Object oriented entities

### DIFF
--- a/src/core.cpp
+++ b/src/core.cpp
@@ -41,8 +41,8 @@ void windowTitleUpdate() {
 
     char title[LEVEL_NAME_BUFFER_SIZE + 20];
 
-    if (LEVEL_STATE->levelName[0] != '\0')
-        sprintf(title, "%s - %d FPS", LEVEL_STATE->levelName, GetFPS());  
+    if (Level::STATE->levelName[0] != '\0')
+        sprintf(title, "%s - %d FPS", Level::STATE->levelName, GetFPS());  
     else
         sprintf(title, "Jogo de Plataforma - %d FPS", GetFPS());  
 
@@ -87,8 +87,8 @@ void SystemsInitialize() {
     CameraInitialize();
     EditorInitialize();
     OverworldInitialize();
-    LevelInitialize();
-    RenderInitialize();
+    Level::Initialize();
+    Render::Initialize();
     TextBank::InitializeAndLoad();
     Sounds::Initialize();
 }
@@ -96,7 +96,7 @@ void SystemsInitialize() {
 void GameUpdate() {
 
     if (GAME_STATE->mode == MODE_IN_LEVEL)
-        LevelTick();
+        Level::Tick();
     else if (GAME_STATE->mode == MODE_OVERWORLD)
         OverworldTick();
 
@@ -112,9 +112,9 @@ void GameExit() {
     exit(0);
 }
 
-ListNode *GetEntityListHead() {
+LinkedList::ListNode *GetEntityListHead() {
 
-    if (GAME_STATE->mode == MODE_IN_LEVEL) return LEVEL_STATE->listHead;
+    if (GAME_STATE->mode == MODE_IN_LEVEL) return Level::STATE->listHead;
     else if (GAME_STATE->mode == MODE_OVERWORLD) return OW_STATE->listHead;
     else return 0;
 }

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -112,7 +112,7 @@ void GameExit() {
     exit(0);
 }
 
-LinkedList::ListNode *GetEntityListHead() {
+LinkedList::Node *GetEntityListHead() {
 
     if (GAME_STATE->mode == MODE_IN_LEVEL) return Level::STATE->listHead;
     else if (GAME_STATE->mode == MODE_OVERWORLD) return OW_STATE->listHead;

--- a/src/core.hpp
+++ b/src/core.hpp
@@ -89,7 +89,7 @@ void GameExit();
 bool IsInPlayArea(Vector2 pos);
 
 // Returns the entity list's head for the current selected game mode
-LinkedList::ListNode *GetEntityListHead();
+LinkedList::Node *GetEntityListHead();
 
 // Enables the debug HUD
 void DebugHudEnable();

--- a/src/core.hpp
+++ b/src/core.hpp
@@ -89,7 +89,7 @@ void GameExit();
 bool IsInPlayArea(Vector2 pos);
 
 // Returns the entity list's head for the current selected game mode
-ListNode *GetEntityListHead();
+LinkedList::ListNode *GetEntityListHead();
 
 // Enables the debug HUD
 void DebugHudEnable();

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -6,15 +6,15 @@
 #include "linked_list.hpp"
 
 
-ListNode *DEBUG_ENTITY_INFO_HEAD = 0;
+LinkedList::ListNode *DEBUG_ENTITY_INFO_HEAD = 0;
 
 
 void DebugEntityToggle(Vector2 pos) {
 
-    void *entity;
+    LinkedList::NodeItem *entity;
     switch (GAME_STATE->mode) {
     case MODE_IN_LEVEL:
-        entity = LevelEntityGetAt(pos); break;
+        entity = Level::EntityGetAt(pos); break;
     case MODE_OVERWORLD:
         entity = OverworldEntityGetAt(pos); break;
     default:
@@ -23,30 +23,30 @@ void DebugEntityToggle(Vector2 pos) {
     
     if (!entity) return;
 
-    ListNode *entitysNode = LinkedListGetNode(DEBUG_ENTITY_INFO_HEAD, entity);
+    LinkedList::ListNode *entitysNode = LinkedList::GetNode(DEBUG_ENTITY_INFO_HEAD, entity);
 
     if (entitysNode) {
-        LinkedListRemoveNode(&DEBUG_ENTITY_INFO_HEAD, entitysNode);
+        LinkedList::RemoveNode(&DEBUG_ENTITY_INFO_HEAD, entitysNode);
         TraceLog(LOG_TRACE, "Debug entity info disabled entity.");
     } else {
-        LinkedListAdd(&DEBUG_ENTITY_INFO_HEAD, entity);
+        LinkedList::Add(&DEBUG_ENTITY_INFO_HEAD, entity);
         TraceLog(LOG_TRACE, "Debug entity info enabled entity.");
     }
 }
 
 void DebugEntityStop(void *entity) {
     
-    ListNode *entitysNode = LinkedListGetNode(DEBUG_ENTITY_INFO_HEAD, entity);
+    LinkedList::ListNode *entitysNode = LinkedList::GetNode(DEBUG_ENTITY_INFO_HEAD, entity);
 
     if (entitysNode) {
-        LinkedListRemoveNode(&DEBUG_ENTITY_INFO_HEAD, entitysNode);
+        LinkedList::RemoveNode(&DEBUG_ENTITY_INFO_HEAD, entitysNode);
         TraceLog(LOG_TRACE, "Debug entity info disabled entity.");
     }
 }
 
 void DebugEntityStopAll() {
 
-    LinkedListRemoveAll(&DEBUG_ENTITY_INFO_HEAD);
+    LinkedList::RemoveAll(&DEBUG_ENTITY_INFO_HEAD);
 
     TraceLog(LOG_TRACE, "Debug entity info disabled all entities.");
 }

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -7,7 +7,7 @@
 #include "linked_list.hpp"
 
 
-std::vector<LinkedList::Node *> DEBUG_ENTITY_LIST = std::vector<LinkedList::Node *>();
+std::vector<LinkedList::Node *> DEBUG_ENTITY_INFO_HEAD = std::vector<LinkedList::Node *>();
 
 
 void DebugEntityToggle(Vector2 pos) {
@@ -24,29 +24,29 @@ void DebugEntityToggle(Vector2 pos) {
     
     if (!entity) return;
 
-    auto idx = std::find(DEBUG_ENTITY_LIST.begin(), DEBUG_ENTITY_LIST.end(), entity);
-    if (idx != DEBUG_ENTITY_LIST.end()) {
-        DEBUG_ENTITY_LIST.erase(idx);
+    auto idx = std::find(DEBUG_ENTITY_INFO_HEAD.begin(), DEBUG_ENTITY_INFO_HEAD.end(), entity);
+    if (idx != DEBUG_ENTITY_INFO_HEAD.end()) {
+        DEBUG_ENTITY_INFO_HEAD.erase(idx);
         TraceLog(LOG_TRACE, "Debug entity info disabled entity.");
     } else {
-        DEBUG_ENTITY_LIST.push_back(entity);
+        DEBUG_ENTITY_INFO_HEAD.push_back(entity);
         TraceLog(LOG_TRACE, "Debug entity info enabled entity.");
     }
 }
 
 void DebugEntityStop(LinkedList::Node *entity) {
 
-    auto idx = std::find(DEBUG_ENTITY_LIST.begin(), DEBUG_ENTITY_LIST.end(), entity);
+    auto idx = std::find(DEBUG_ENTITY_INFO_HEAD.begin(), DEBUG_ENTITY_INFO_HEAD.end(), entity);
 
-    if (idx != DEBUG_ENTITY_LIST.end()) {
-        DEBUG_ENTITY_LIST.erase(idx);
+    if (idx != DEBUG_ENTITY_INFO_HEAD.end()) {
+        DEBUG_ENTITY_INFO_HEAD.erase(idx);
         TraceLog(LOG_TRACE, "Debug entity info disabled entity.");
     }
 }
 
 void DebugEntityStopAll() {
 
-    DEBUG_ENTITY_LIST.clear();
+    DEBUG_ENTITY_INFO_HEAD.clear();
 
     TraceLog(LOG_TRACE, "Debug entity info disabled all entities.");
 }

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -1,4 +1,5 @@
 #include <raylib.h>
+#include <algorithm>
 
 #include "debug.hpp"
 #include "level/level.hpp"
@@ -6,12 +7,12 @@
 #include "linked_list.hpp"
 
 
-LinkedList::ListNode *DEBUG_ENTITY_INFO_HEAD = 0;
+std::vector<LinkedList::Node *> DEBUG_ENTITY_LIST = std::vector<LinkedList::Node *>();
 
 
 void DebugEntityToggle(Vector2 pos) {
 
-    LinkedList::NodeItem *entity;
+    LinkedList::Node *entity;
     switch (GAME_STATE->mode) {
     case MODE_IN_LEVEL:
         entity = Level::EntityGetAt(pos); break;
@@ -23,30 +24,29 @@ void DebugEntityToggle(Vector2 pos) {
     
     if (!entity) return;
 
-    LinkedList::ListNode *entitysNode = LinkedList::GetNode(DEBUG_ENTITY_INFO_HEAD, entity);
-
-    if (entitysNode) {
-        LinkedList::RemoveNode(&DEBUG_ENTITY_INFO_HEAD, entitysNode);
+    auto idx = std::find(DEBUG_ENTITY_LIST.begin(), DEBUG_ENTITY_LIST.end(), entity);
+    if (idx != DEBUG_ENTITY_LIST.end()) {
+        DEBUG_ENTITY_LIST.erase(idx);
         TraceLog(LOG_TRACE, "Debug entity info disabled entity.");
     } else {
-        LinkedList::Add(&DEBUG_ENTITY_INFO_HEAD, entity);
+        DEBUG_ENTITY_LIST.push_back(entity);
         TraceLog(LOG_TRACE, "Debug entity info enabled entity.");
     }
 }
 
-void DebugEntityStop(void *entity) {
-    
-    LinkedList::ListNode *entitysNode = LinkedList::GetNode(DEBUG_ENTITY_INFO_HEAD, entity);
+void DebugEntityStop(LinkedList::Node *entity) {
 
-    if (entitysNode) {
-        LinkedList::RemoveNode(&DEBUG_ENTITY_INFO_HEAD, entitysNode);
+    auto idx = std::find(DEBUG_ENTITY_LIST.begin(), DEBUG_ENTITY_LIST.end(), entity);
+
+    if (idx != DEBUG_ENTITY_LIST.end()) {
+        DEBUG_ENTITY_LIST.erase(idx);
         TraceLog(LOG_TRACE, "Debug entity info disabled entity.");
     }
 }
 
 void DebugEntityStopAll() {
 
-    LinkedList::RemoveAll(&DEBUG_ENTITY_INFO_HEAD);
+    DEBUG_ENTITY_LIST.clear();
 
     TraceLog(LOG_TRACE, "Debug entity info disabled all entities.");
 }

--- a/src/debug.hpp
+++ b/src/debug.hpp
@@ -9,7 +9,7 @@
 #include "level/level.hpp"
 
 
-extern std::vector<LinkedList::Node *> DEBUG_ENTITY_LIST;
+extern std::vector<LinkedList::Node *> DEBUG_ENTITY_INFO_HEAD;
 
 
 // Searches for entity at pos and, if it finds one, shows

--- a/src/debug.hpp
+++ b/src/debug.hpp
@@ -8,7 +8,7 @@
 #include "level/level.hpp"
 
 
-extern ListNode *DEBUG_ENTITY_INFO_HEAD;
+extern LinkedList::ListNode *DEBUG_ENTITY_INFO_HEAD;
 
 
 // Searches for entity at pos and, if it finds one, shows

--- a/src/debug.hpp
+++ b/src/debug.hpp
@@ -3,12 +3,13 @@
 
 
 #include <raylib.h>
+#include <vector>
 
 #include "linked_list.hpp"
 #include "level/level.hpp"
 
 
-extern LinkedList::ListNode *DEBUG_ENTITY_INFO_HEAD;
+extern std::vector<LinkedList::Node *> DEBUG_ENTITY_LIST;
 
 
 // Searches for entity at pos and, if it finds one, shows
@@ -16,7 +17,7 @@ extern LinkedList::ListNode *DEBUG_ENTITY_INFO_HEAD;
 void DebugEntityToggle(Vector2 pos);
 
 // Stops showing info about an entity. If it's not showing already, does nothing.
-void DebugEntityStop(void *entity);
+void DebugEntityStop(LinkedList::Node *entity);
 
 // Stops showing info about all entities.
 void DebugEntityStopAll();

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -33,7 +33,7 @@ static void editorUseEraser(Vector2 cursorPos) {
     switch (GAME_STATE->mode) {
         
     case MODE_IN_LEVEL:
-        LevelEntityRemoveAt(cursorPos);
+        Level::EntityRemoveAt(cursorPos);
         break;
     
     case MODE_OVERWORLD:
@@ -48,25 +48,25 @@ static void editorUseEraser(Vector2 cursorPos) {
 static EditorEntityButton *addEntityButton(
     EditorEntityType type, Sprite sprite, void (*handler)(Vector2), EditorInteractionType interaction) {
 
-        EditorEntityButton *newButton = (EditorEntityButton *) MemAlloc(sizeof(EditorEntityButton));
+        EditorEntityButton *newButton = new EditorEntityButton();
         newButton->type = type;
         newButton->handler = handler;
         newButton->sprite = sprite;
         newButton->interactionType = interaction;
 
-        LinkedListAdd(&EDITOR_STATE->entitiesHead, newButton);
+        LinkedList::Add(&EDITOR_STATE->entitiesHead, newButton);
 
         return newButton;
 }
 
 EditorControlButton *addControlButton(EditorControlType type, char *label, void (*handler)()) {
 
-    EditorControlButton *newButton = (EditorControlButton *) MemAlloc(sizeof(EditorControlButton));
+    EditorControlButton *newButton = new EditorControlButton();
     newButton->type = type;
     newButton->handler = handler;
     newButton->label = label;
 
-    LinkedListAdd(&EDITOR_STATE->controlHead, newButton);
+    LinkedList::Add(&EDITOR_STATE->controlHead, newButton);
 
     return newButton;
 }
@@ -78,12 +78,12 @@ void loadInLevelEditor() {
     EDITOR_STATE->defaultEntityButton =
         addEntityButton(EDITOR_ENTITY_BLOCK, SPRITES->Block, &BlockCheckAndAdd, EDITOR_INTERACTION_HOLD);
     addEntityButton(EDITOR_ENTITY_ACID, SPRITES->Acid, &AcidCheckAndAdd, EDITOR_INTERACTION_HOLD);   
-    addEntityButton(EDITOR_ENTITY_EXIT, SPRITES->LevelEndOrb, &LevelExitCheckAndAdd, EDITOR_INTERACTION_CLICK);
+    addEntityButton(EDITOR_ENTITY_EXIT, SPRITES->LevelEndOrb, &Level::ExitCheckAndAdd, EDITOR_INTERACTION_CLICK);
     addEntityButton(EDITOR_ENTITY_GLIDE, SPRITES->GlideItem, &GlideCheckAndAdd, EDITOR_INTERACTION_CLICK);
-    addEntityButton(EDITOR_ENTITY_TEXTBOX, SPRITES->TextboxButton, &LevelTextboxCheckAndAdd, EDITOR_INTERACTION_CLICK);
+    addEntityButton(EDITOR_ENTITY_TEXTBOX, SPRITES->TextboxButton, &Level::TextboxCheckAndAdd, EDITOR_INTERACTION_CLICK);
 
-    addControlButton(EDITOR_CONTROL_SAVE, (char *) "Salvar fase", &LevelSave);
-    addControlButton(EDITOR_CONTROL_NEW_LEVEL, (char *) "Nova fase", &LevelLoadNew);
+    addControlButton(EDITOR_CONTROL_SAVE, (char *) "Salvar fase", &Level::Save);
+    addControlButton(EDITOR_CONTROL_NEW_LEVEL, (char *) "Nova fase", &Level::LoadNew);
 
     TraceLog(LOG_TRACE, "Editor loaded in level itens.");
 }
@@ -98,7 +98,7 @@ void loadOverworldEditor() {
     addEntityButton(EDITOR_ENTITY_PATH_IN_L, SPRITES->PathTileInL, &OverworldTileAddOrInteract, EDITOR_INTERACTION_CLICK);
 
     addControlButton(EDITOR_CONTROL_SAVE, (char *) "Salvar mundo", &OverworldSave);
-    addControlButton(EDITOR_CONTROL_NEW_LEVEL, (char *) "Nova fase", &LevelLoadNew);
+    addControlButton(EDITOR_CONTROL_NEW_LEVEL, (char *) "Nova fase", &Level::LoadNew);
 
     TraceLog(LOG_TRACE, "Editor loaded overworld itens.");
 }
@@ -107,34 +107,34 @@ void loadOverworldEditor() {
 // based on its origin and current cursor pos
 static void updateEntitySelectionList() {
 
-    LinkedListRemoveAll(&EDITOR_STATE->selectedEntities);
+    LinkedList::RemoveAll(&EDITOR_STATE->selectedEntities);
 
     Rectangle selectionHitbox = EditorSelectionGetRect();
 
-    ListNode *node = GetEntityListHead();
+    LinkedList::ListNode *node = GetEntityListHead();
     while (node != 0) {
 
         if (GAME_STATE->mode == MODE_IN_LEVEL) {
-            LevelEntity *entity = (LevelEntity *) node->item;
+            Level::Entity *entity = (Level::Entity *) node->item;
             
-            if (entity->components & LEVEL_IS_PLAYER) goto next_entity;
+            if (entity->tags & Level::IS_PLAYER) goto next_entity;
 
             bool collisionWithEntity = !entity->isDead && CheckCollisionRecs(selectionHitbox, entity->hitbox);
-            bool collisionWithGhost = CheckCollisionRecs(selectionHitbox, LevelEntityOriginHitbox(entity));
+            bool collisionWithGhost = CheckCollisionRecs(selectionHitbox, Level::EntityOriginHitbox(entity));
             if (collisionWithEntity || collisionWithGhost) {
                 
-                LinkedListAdd(&EDITOR_STATE->selectedEntities, entity);
+                LinkedList::Add(&EDITOR_STATE->selectedEntities, entity);
             }
         }
         else if (GAME_STATE->mode == MODE_OVERWORLD) {
             
             OverworldEntity *entity = (OverworldEntity *) node->item;
             
-            if (entity->components & OW_IS_CURSOR) goto next_entity;
+            if (entity->tags & OW_IS_CURSOR) goto next_entity;
 
             if (CheckCollisionRecs(selectionHitbox, OverworldEntitySquare(entity))) {
                 
-                LinkedListAdd(&EDITOR_STATE->selectedEntities, entity);
+                LinkedList::Add(&EDITOR_STATE->selectedEntities, entity);
             }
         }
 
@@ -146,17 +146,17 @@ next_entity:
 void selectEntitiesApplyMove() {
 
     // Searches for collision 
-    ListNode *node = EDITOR_STATE->selectedEntities;
+    LinkedList::ListNode *node = EDITOR_STATE->selectedEntities;
     while (node) {
 
         switch (GAME_STATE->mode) {
 
         case MODE_IN_LEVEL: {
-            LevelEntity *entity = (LevelEntity *) node->item;
+            Level::Entity *entity = (Level::Entity *) node->item;
             Rectangle hitbox = entity->hitbox;
             Vector2 pos = EditorEntitySelectionCalcMove(RectangleGetPos(hitbox));
             RectangleSetPos(&hitbox, pos);
-            if (LevelCheckCollisionWithAnythingElse(hitbox, EDITOR_STATE->selectedEntities))
+            if (Level::CheckCollisionWithAnythingElse(hitbox, EDITOR_STATE->selectedEntities))
                 return;
             break;
         }
@@ -184,7 +184,7 @@ void selectEntitiesApplyMove() {
         switch (GAME_STATE->mode) {
 
         case MODE_IN_LEVEL: {
-            LevelEntity *entity = (LevelEntity *) node->item;
+            Level::Entity *entity = (Level::Entity *) node->item;
             newPos = EditorEntitySelectionCalcMove(RectangleGetPos(entity->hitbox));
             RectangleSetPos(&entity->hitbox, newPos);
             entity->origin = EditorEntitySelectionCalcMove(entity->origin);
@@ -242,8 +242,8 @@ void EditorSync() {
 
 void EditorEmpty() {
 
-    LinkedListDestroyAll(&EDITOR_STATE->entitiesHead);
-    LinkedListDestroyAll(&EDITOR_STATE->controlHead);
+    LinkedList::DestroyAll(&EDITOR_STATE->entitiesHead);
+    LinkedList::DestroyAll(&EDITOR_STATE->controlHead);
     EDITOR_STATE->defaultEntityButton = 0;
     EDITOR_STATE->toggledEntityButton = 0;
 
@@ -254,7 +254,7 @@ void EditorEnable() {
 
     EDITOR_STATE->isEnabled = true;
 
-    RenderResizeWindow(SCREEN_WIDTH_W_EDITOR, SCREEN_HEIGHT);
+    Render::ResizeWindow(SCREEN_WIDTH_W_EDITOR, SCREEN_HEIGHT);
     MouseCursorEnable();
 
     buttonsSelectDefault();
@@ -266,7 +266,7 @@ void EditorDisable() {
 
     EDITOR_STATE->isEnabled = false;
 
-    RenderResizeWindow(SCREEN_WIDTH, SCREEN_HEIGHT);
+    Render::ResizeWindow(SCREEN_WIDTH, SCREEN_HEIGHT);
 
     MouseCursorDisable();
 
@@ -329,7 +329,7 @@ void EditorSelectionCancel() {
     EDITOR_STATE->isSelectingEntities = false;
     EDITOR_STATE->selectedEntitiesThisFrame = false;
     EDITOR_STATE->isMovingSelectedEntities = false;
-    LinkedListRemoveAll(&EDITOR_STATE->selectedEntities);
+    LinkedList::RemoveAll(&EDITOR_STATE->selectedEntities);
 
     TraceLog(LOG_TRACE, "Editor's entity selection canceled.");
 }

--- a/src/editor.hpp
+++ b/src/editor.hpp
@@ -75,14 +75,15 @@ typedef enum {
     EDITOR_INTERACTION_HOLD
 } EditorInteractionType;
 
-typedef struct EditorEntityButton {
+class EditorEntityButton : public LinkedList::NodeItem {
 
+public:
     EditorEntityType type;
     Sprite sprite;
     void (*handler)(Vector2); // Receives the click scene pos
     EditorInteractionType interactionType;
 
-} EditorEntityButton;
+};
 
 
 typedef enum { 
@@ -90,13 +91,14 @@ typedef enum {
     EDITOR_CONTROL_NEW_LEVEL
 } EditorControlType;
 
-typedef struct EditorControlButton {
+class EditorControlButton : public LinkedList::NodeItem {
 
+public:
     EditorControlType type;
     char *label;
     void (*handler)();
 
-} EditorControlButton;
+};
 
 
 typedef struct EditorState {
@@ -105,8 +107,8 @@ typedef struct EditorState {
     bool isEnabled;
 
     // The heads for each button list
-    ListNode *entitiesHead;
-    ListNode *controlHead;
+    LinkedList::ListNode *entitiesHead;
+    LinkedList::ListNode *controlHead;
 
     // What entity button is currently selected in the editor
     EditorEntityButton *toggledEntityButton;
@@ -114,10 +116,10 @@ typedef struct EditorState {
     EditorEntityButton *defaultEntityButton;
 
     // Entity selection
-    bool        isSelectingEntities;
-    bool        selectedEntitiesThisFrame;
-    Trajectory  entitySelectionCoords;
-    ListNode *  selectedEntities;
+    bool                    isSelectingEntities;
+    bool                    selectedEntitiesThisFrame;
+    Trajectory              entitySelectionCoords;
+    LinkedList::ListNode    *selectedEntities;
 
     // Moving selected entities
     bool        isMovingSelectedEntities;

--- a/src/editor.hpp
+++ b/src/editor.hpp
@@ -3,6 +3,7 @@
 
 
 #include <raylib.h>
+#include <vector>
 
 #include "assets.hpp"
 #include "linked_list.hpp"
@@ -75,7 +76,7 @@ typedef enum {
     EDITOR_INTERACTION_HOLD
 } EditorInteractionType;
 
-class EditorEntityButton : public LinkedList::NodeItem {
+class EditorEntityButton : public LinkedList::Node {
 
 public:
     EditorEntityType type;
@@ -91,7 +92,7 @@ typedef enum {
     EDITOR_CONTROL_NEW_LEVEL
 } EditorControlType;
 
-class EditorControlButton : public LinkedList::NodeItem {
+class EditorControlButton : public LinkedList::Node {
 
 public:
     EditorControlType type;
@@ -107,19 +108,20 @@ typedef struct EditorState {
     bool isEnabled;
 
     // The heads for each button list
-    LinkedList::ListNode *entitiesHead;
-    LinkedList::ListNode *controlHead;
+    LinkedList::Node    *entitiesHead;
+    LinkedList::Node    *controlHead;
 
     // What entity button is currently selected in the editor
     EditorEntityButton *toggledEntityButton;
 
     EditorEntityButton *defaultEntityButton;
 
+
     // Entity selection
-    bool                    isSelectingEntities;
-    bool                    selectedEntitiesThisFrame;
-    Trajectory              entitySelectionCoords;
-    LinkedList::ListNode    *selectedEntities;
+    bool                            isSelectingEntities;
+    bool                            selectedEntitiesThisFrame;
+    Trajectory                      entitySelectionCoords;
+    std::vector<LinkedList::Node *> selectedEntities;
 
     // Moving selected entities
     bool        isMovingSelectedEntities;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -25,7 +25,7 @@ int main() {
 
         GameUpdate();
 
-        Render();
+        Render::Render();
     }
 
     CloseWindow();

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -69,14 +69,14 @@ void handleInLevelInput() {
 
 
     if (IsKeyPressed(KEY_BACKSPACE) || isGamepadPressed(GP_SELECT))
-        { LevelGoToOverworld(); return; }
+        { Level::GoToOverworld(); return; }
 
 
     if (IsKeyPressed(KEY_ENTER) || isGamepadPressed(GP_START))
-        { LevelPauseToggle(); return; }
+        { Level::PauseToggle(); return; }
 
 
-    if (LEVEL_STATE->isPaused || !PLAYER_ENTITY || PLAYER_ENTITY->isDead) return;
+    if (Level::STATE->isPaused || !PLAYER_ENTITY || PLAYER_ENTITY->isDead) return;
 
 
     STATE.isHoldingRun = IsKeyDown(KEY_Z) || isGamepadDown(GP_X);
@@ -232,16 +232,16 @@ void handleDroppedFile() {
     
     if (PersistenceGetDroppedLevelName(levelName)) {
         
-        LevelLoad(levelName);
+        Level::Load(levelName);
         
-        if (LEVEL_STATE->awaitingAssociation) {
+        if (Level::STATE->awaitingAssociation) {
 
             strcpy(OW_STATE->tileUnderCursor->levelName, levelName);
 
             TraceLog(LOG_INFO, "Dot on x=%.1f, y=%.1f associated with level %s.",
                         OW_STATE->tileUnderCursor->gridPos.x, OW_STATE->tileUnderCursor->gridPos.y, levelName);
             
-            RenderPrintSysMessage("Associada fase " + std::string(levelName));
+            Render::PrintSysMessage("Associada fase " + std::string(levelName));
         }
     }
 

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -158,7 +158,7 @@ void handleDevInput() {
         EditorSelectEntities(mousePosInScene);
         return;
     }
-    else if (EDITOR_STATE->isEnabled && IsMouseButtonDown(MOUSE_BUTTON_LEFT) && EDITOR_STATE->selectedEntities) {
+    else if (EDITOR_STATE->isEnabled && IsMouseButtonDown(MOUSE_BUTTON_LEFT) && !EDITOR_STATE->selectedEntities.empty()) {
 
         if (!IsInPlayArea(mousePosInScreen)) goto skip_selected_entities_actions;
 

--- a/src/level/block.cpp
+++ b/src/level/block.cpp
@@ -6,15 +6,15 @@
 
 void BlockAdd(Vector2 origin) {
 
-    LevelEntity *newBlock = (LevelEntity *) MemAlloc(sizeof(LevelEntity));
+    Level::Entity *newBlock = new Level::Entity();
 
-    newBlock->components = LEVEL_IS_SCENARIO +
-                            LEVEL_IS_GROUND;
+    newBlock->tags = Level::IS_SCENARIO +
+                            Level::IS_GROUND;
     newBlock->origin = origin;
     newBlock->sprite = SPRITES->Block;
     newBlock->hitbox = SpriteHitboxFromEdge(newBlock->sprite, newBlock->origin);
 
-    LinkedListAdd(&LEVEL_STATE->listHead, newBlock);
+    LinkedList::Add(&Level::STATE->listHead, newBlock);
 
     TraceLog(LOG_TRACE, "Added block to level (x=%.1f, y=%.1f)",
                 newBlock->hitbox.x, newBlock->hitbox.y);
@@ -25,23 +25,23 @@ void BlockCheckAndAdd(Vector2 origin) {
     origin = SnapToGrid(origin, LEVEL_GRID);
 
     Rectangle hitbox = SpriteHitboxFromEdge(SPRITES->Block, origin);
-    if (LevelCheckCollisionWithAnything(hitbox)) return;
+    if (Level::CheckCollisionWithAnything(hitbox)) return;
     
     BlockAdd(origin);
 }
 
 void AcidAdd(Vector2 origin) {
 
-    LevelEntity *newBlock = (LevelEntity *) MemAlloc(sizeof(LevelEntity));
+    Level::Entity *newBlock = new Level::Entity();
 
-    newBlock->components = LEVEL_IS_SCENARIO +
-                            LEVEL_IS_GROUND +
-                            LEVEL_IS_DANGER;
+    newBlock->tags = Level::IS_SCENARIO +
+                            Level::IS_GROUND +
+                            Level::IS_DANGER;
     newBlock->origin = origin;
     newBlock->sprite = SPRITES->Acid;
     newBlock->hitbox = SpriteHitboxFromEdge(newBlock->sprite, newBlock->origin);
 
-    LinkedListAdd(&LEVEL_STATE->listHead, newBlock);
+    LinkedList::Add(&Level::STATE->listHead, newBlock);
 
     TraceLog(LOG_TRACE, "Added acid block to level (x=%.1f, y=%.1f)",
                 newBlock->hitbox.x, newBlock->hitbox.y);
@@ -52,7 +52,7 @@ void AcidCheckAndAdd(Vector2 origin) {
     origin = SnapToGrid(origin, LEVEL_GRID);
 
     Rectangle hitbox = SpriteHitboxFromEdge(SPRITES->Acid, origin);
-    if (LevelCheckCollisionWithAnything(hitbox)) return;
+    if (Level::CheckCollisionWithAnything(hitbox)) return;
     
     AcidAdd(origin);
 }

--- a/src/level/block.cpp
+++ b/src/level/block.cpp
@@ -14,7 +14,7 @@ void BlockAdd(Vector2 origin) {
     newBlock->sprite = SPRITES->Block;
     newBlock->hitbox = SpriteHitboxFromEdge(newBlock->sprite, newBlock->origin);
 
-    LinkedList::Add(&Level::STATE->listHead, newBlock);
+    LinkedList::AddNode(&Level::STATE->listHead, newBlock);
 
     TraceLog(LOG_TRACE, "Added block to level (x=%.1f, y=%.1f)",
                 newBlock->hitbox.x, newBlock->hitbox.y);
@@ -41,7 +41,7 @@ void AcidAdd(Vector2 origin) {
     newBlock->sprite = SPRITES->Acid;
     newBlock->hitbox = SpriteHitboxFromEdge(newBlock->sprite, newBlock->origin);
 
-    LinkedList::Add(&Level::STATE->listHead, newBlock);
+    LinkedList::AddNode(&Level::STATE->listHead, newBlock);
 
     TraceLog(LOG_TRACE, "Added acid block to level (x=%.1f, y=%.1f)",
                 newBlock->hitbox.x, newBlock->hitbox.y);

--- a/src/level/enemy.cpp
+++ b/src/level/enemy.cpp
@@ -11,18 +11,18 @@
 
 void EnemyAdd(Vector2 origin) {
 
-    LevelEntity *newEnemy = (LevelEntity *) MemAlloc(sizeof(LevelEntity));
+    Level::Entity *newEnemy = new Level::Entity();
 
-    newEnemy->components = LEVEL_IS_ENEMY +
-                            LEVEL_IS_GROUND +
-                            LEVEL_IS_DANGER;
+    newEnemy->tags = Level::IS_ENEMY +
+                            Level::IS_GROUND +
+                            Level::IS_DANGER;
     newEnemy->origin = origin;
     newEnemy->sprite = SPRITES->Enemy;
     newEnemy->hitbox = SpriteHitboxFromEdge(newEnemy->sprite, newEnemy->origin);
     newEnemy->isFacingRight = true;
     newEnemy->isFallingDown = true;
 
-    LinkedListAdd(&LEVEL_STATE->listHead, newEnemy);
+    LinkedList::Add(&Level::STATE->listHead, newEnemy);
 
     TraceLog(LOG_TRACE, "Added enemy to level (x=%.1f, y=%.1f)",
                 newEnemy->hitbox.x, newEnemy->hitbox.y);
@@ -32,7 +32,7 @@ void EnemyCheckAndAdd(Vector2 origin) {
 
     Rectangle hitbox = SpriteHitboxFromMiddle(SPRITES->Enemy, origin);
 
-    if (LevelCheckCollisionWithAnything(hitbox)) {
+    if (Level::CheckCollisionWithAnything(hitbox)) {
         TraceLog(LOG_DEBUG, "Couldn't add enemy to level, collision with entity.");
         return;
     }
@@ -40,15 +40,15 @@ void EnemyCheckAndAdd(Vector2 origin) {
     EnemyAdd({ hitbox.x, hitbox.y });
 }
 
-void EnemyTick(ListNode *enemyNode) {
+void EnemyTick(LinkedList::ListNode *enemyNode) {
 
-    if (LEVEL_STATE->concludedAgo >= 0) return;
+    if (Level::STATE->concludedAgo >= 0) return;
 
-    LevelEntity *enemy = (LevelEntity *)enemyNode->item;
+    Level::Entity *enemy = (Level::Entity *)enemyNode->item;
     if (enemy->isDead) return;
 
 
-    LevelEntity *groundBeneath = LevelGetGroundBeneath(enemy);
+    Level::Entity *groundBeneath = Level::GetGroundBeneath(enemy);
 
     if (!groundBeneath) enemy->isFallingDown = true;
 
@@ -90,14 +90,14 @@ void EnemyTick(ListNode *enemyNode) {
     if (enemy->isFacingRight) enemy->hitbox.x += ENEMY_SPEED_DEFAULT;
     else enemy->hitbox.x -= ENEMY_SPEED_DEFAULT;
 
-    ListNode *node = LEVEL_STATE->listHead;
+    LinkedList::ListNode *node = Level::STATE->listHead;
     while (node) {
 
-        LevelEntity *entity = (LevelEntity *) node->item;
+        Level::Entity *entity = (Level::Entity *) node->item;
 
         if (entity == enemy) goto next_node;
 
-        if (entity->components & LEVEL_IS_SCENARIO &&
+        if (entity->tags & Level::IS_SCENARIO &&
             CheckCollisionRecs(entity->hitbox, enemy->hitbox)) {
 
                 enemy->isFacingRight = !enemy->isFacingRight;
@@ -110,7 +110,7 @@ next_node:
     }
 }
 
-void EnemyKill(LevelEntity *entity) {
+void EnemyKill(Level::Entity *entity) {
 
     entity->isDead = true;
 

--- a/src/level/enemy.cpp
+++ b/src/level/enemy.cpp
@@ -40,11 +40,10 @@ void EnemyCheckAndAdd(Vector2 origin) {
     EnemyAdd({ hitbox.x, hitbox.y });
 }
 
-void EnemyTick(LinkedList::Node *enemyNode) {
+void EnemyTick(Level::Entity *enemy) {
 
     if (Level::STATE->concludedAgo >= 0) return;
 
-    Level::Entity *enemy = (Level::Entity *)enemyNode;
     if (enemy->isDead) return;
 
 
@@ -110,11 +109,11 @@ next_node:
     }
 }
 
-void EnemyKill(Level::Entity *entity) {
+void EnemyKill(Level::Entity *enemy) {
 
-    entity->isDead = true;
+    enemy->isDead = true;
 
-    DebugEntityStop(entity);
+    DebugEntityStop(enemy);
 
     TraceLog(LOG_TRACE, "Enemy died.");
 }

--- a/src/level/enemy.cpp
+++ b/src/level/enemy.cpp
@@ -22,7 +22,7 @@ void EnemyAdd(Vector2 origin) {
     newEnemy->isFacingRight = true;
     newEnemy->isFallingDown = true;
 
-    LinkedList::Add(&Level::STATE->listHead, newEnemy);
+    LinkedList::AddNode(&Level::STATE->listHead, newEnemy);
 
     TraceLog(LOG_TRACE, "Added enemy to level (x=%.1f, y=%.1f)",
                 newEnemy->hitbox.x, newEnemy->hitbox.y);
@@ -40,11 +40,11 @@ void EnemyCheckAndAdd(Vector2 origin) {
     EnemyAdd({ hitbox.x, hitbox.y });
 }
 
-void EnemyTick(LinkedList::ListNode *enemyNode) {
+void EnemyTick(LinkedList::Node *enemyNode) {
 
     if (Level::STATE->concludedAgo >= 0) return;
 
-    Level::Entity *enemy = (Level::Entity *)enemyNode->item;
+    Level::Entity *enemy = (Level::Entity *)enemyNode;
     if (enemy->isDead) return;
 
 
@@ -90,10 +90,10 @@ void EnemyTick(LinkedList::ListNode *enemyNode) {
     if (enemy->isFacingRight) enemy->hitbox.x += ENEMY_SPEED_DEFAULT;
     else enemy->hitbox.x -= ENEMY_SPEED_DEFAULT;
 
-    LinkedList::ListNode *node = Level::STATE->listHead;
+    LinkedList::Node *node = Level::STATE->listHead;
     while (node) {
 
-        Level::Entity *entity = (Level::Entity *) node->item;
+        Level::Entity *entity = (Level::Entity *) node;
 
         if (entity == enemy) goto next_node;
 

--- a/src/level/enemy.hpp
+++ b/src/level/enemy.hpp
@@ -15,10 +15,10 @@ void EnemyAdd(Vector2 origin);
 void EnemyCheckAndAdd(Vector2 origin);
 
 // Runs the update routine of a given enemy
-void EnemyTick(ListNode *enemyNode);
+void EnemyTick(LinkedList::ListNode *enemyNode);
 
 // Kills a given enemy
-void EnemyKill(LevelEntity *entity);
+void EnemyKill(Level::Entity *entity);
 
 
 #endif // _ENEMY_H_INCLUDED_

--- a/src/level/enemy.hpp
+++ b/src/level/enemy.hpp
@@ -15,10 +15,10 @@ void EnemyAdd(Vector2 origin);
 void EnemyCheckAndAdd(Vector2 origin);
 
 // Runs the update routine of a given enemy
-void EnemyTick(LinkedList::Node *enemyNode);
+void EnemyTick(Level::Entity *enemy);
 
 // Kills a given enemy
-void EnemyKill(Level::Entity *entity);
+void EnemyKill(Level::Entity *enemy);
 
 
 #endif // _ENEMY_H_INCLUDED_

--- a/src/level/enemy.hpp
+++ b/src/level/enemy.hpp
@@ -15,7 +15,7 @@ void EnemyAdd(Vector2 origin);
 void EnemyCheckAndAdd(Vector2 origin);
 
 // Runs the update routine of a given enemy
-void EnemyTick(LinkedList::ListNode *enemyNode);
+void EnemyTick(LinkedList::Node *enemyNode);
 
 // Kills a given enemy
 void EnemyKill(Level::Entity *entity);

--- a/src/level/level.cpp
+++ b/src/level/level.cpp
@@ -13,6 +13,7 @@
 #include "../overworld.hpp"
 #include "../debug.hpp"
 #include "../input.hpp"
+#include "../render.hpp"
 
 
 // The difference between the y of the hitbox and the ground to be considered "on the ground"
@@ -29,39 +30,42 @@
 #define STARTING_CHECKPOINTS_NUMBER     1;
 
 
-LevelState *LEVEL_STATE = 0;
+namespace Level {
 
 
-void resetLevelState() {
+LevelState *STATE = 0;
 
-    LinkedListDestroyAll(&LEVEL_STATE->listHead);
-    memset(LEVEL_STATE->levelName, 0, sizeof(LEVEL_STATE->levelName));
-    LEVEL_STATE->isPaused = false;
-    LEVEL_STATE->awaitingAssociation = false;
-    LEVEL_STATE->concludedAgo = -1;
-    LEVEL_STATE->exitNode = 0;
-    LEVEL_STATE->checkpoint = 0;
-    LEVEL_STATE->checkpointsLeft = 0;
+
+void resetState() {
+
+    LinkedList::DestroyAll(&STATE->listHead);
+    memset(STATE->levelName, 0, sizeof(STATE->levelName));
+    STATE->isPaused = false;
+    STATE->awaitingAssociation = false;
+    STATE->concludedAgo = -1;
+    STATE->exitNode = 0;
+    STATE->checkpoint = 0;
+    STATE->checkpointsLeft = 0;
 
     PLAYER_ENTITY = 0;
 
     TraceLog(LOG_INFO, "Level State initialized.");
 }
 
-void initializeLevelState() {
+void initializeState() {
 
-    LEVEL_STATE = (LevelState *) MemAlloc(sizeof(LevelState));
+    STATE = (LevelState *) MemAlloc(sizeof(LevelState));
 
-    resetLevelState();
+    resetState();
 
     TraceLog(LOG_INFO, "Level State initialized.");
 }
 
-void leaveLevel() {
+void leave() {
     
-    RenderDisplayTextboxStop();
+    Render::DisplayTextboxStop();
     
-    resetLevelState();
+    resetState();
 
     OverworldLoad();
 
@@ -70,13 +74,13 @@ void leaveLevel() {
 
 // Searches for an entity in a given position
 // and returns its node, or 0 if not found.
-static ListNode *getEntityNodeAtPos(Vector2 pos) {
+static LinkedList::ListNode *getEntityNodeAtPos(Vector2 pos) {
 
-    ListNode *node = LEVEL_STATE->listHead;
+    LinkedList::ListNode *node = STATE->listHead;
 
     while (node != 0) {
 
-        LevelEntity *entity = (LevelEntity *) node->item;
+        Entity *entity = (Entity *) node->item;
 
         if (CheckCollisionPointRec(pos, entity->hitbox)) {
 
@@ -91,17 +95,17 @@ static ListNode *getEntityNodeAtPos(Vector2 pos) {
 
 void tickAllEntities() {
 
-    ListNode *node = LEVEL_STATE->listHead;
-    ListNode *next;
+    LinkedList::ListNode *node = STATE->listHead;
+    LinkedList::ListNode *next;
 
     while (node != 0) {
 
         next = node->next;
 
-        LevelEntity *entity = (LevelEntity *)node->item;
+        Entity *entity = (Entity *)node->item;
 
-        if (entity->components & LEVEL_IS_ENEMY) EnemyTick(node);
-        else if (entity->components & LEVEL_IS_PLAYER) PlayerTick();
+        if (entity->tags & IS_ENEMY) EnemyTick(node);
+        else if (entity->tags & IS_PLAYER) PlayerTick();
 
         node = next;
     }
@@ -110,10 +114,10 @@ void tickAllEntities() {
 // Searches the level for a ground immediatelly beneath the hitbox.
 // Accepts an optional 'entity' reference, in case its checking for ground
 // beneath an existing level entity.
-static LevelEntity *getGroundBeneath(Rectangle hitbox, LevelEntity *entity) {
+static Entity *getGroundBeneath(Rectangle hitbox, Entity *entity) {
 
     // Virtual entity to use when checking only hitboxes
-    LevelEntity virtualEntity;
+    Entity virtualEntity;
     if (!entity) {
         virtualEntity.isFacingRight = false;
         entity = &virtualEntity;
@@ -121,16 +125,16 @@ static LevelEntity *getGroundBeneath(Rectangle hitbox, LevelEntity *entity) {
 
     int feetHeight = hitbox.y + hitbox.height;
 
-    ListNode *node = LEVEL_STATE->listHead;
+    LinkedList::ListNode *node = STATE->listHead;
 
-    LevelEntity *foundGround = 0; 
+    Entity *foundGround = 0; 
 
     while (node != 0) {
 
-        LevelEntity *possibleGround = (LevelEntity *)node->item;
+        Entity *possibleGround = (Entity *)node->item;
 
         if (possibleGround != entity &&
-            possibleGround->components & LEVEL_IS_GROUND &&
+            possibleGround->tags & IS_GROUND &&
 
             !(possibleGround->isDead) &&
 
@@ -172,25 +176,25 @@ void createTextboxFromIdInput(Vector2 pos, std::string input) {
         id = std::stoi(input);
     }
     catch (std::invalid_argument &e) {
-        RenderPrintSysMessage("ID inválido");
+        Render::PrintSysMessage("ID inválido");
         TraceLog(LOG_DEBUG, "Textbox ID input invalid: %s.", input.c_str());
         return; // does nothing
     }
 
-    LevelTextboxAdd(pos, id);
+    TextboxAdd(pos, id);
 }
 
-void LevelInitialize() {
+void Initialize() {
 
-    initializeLevelState();
+    initializeState();
     TraceLog(LOG_INFO, "Level system initialized.");
 }
 
-void LevelLoad(char *levelName) {
+void Load(char *levelName) {
 
     // Gambiarra. In case a level file was dragged and there was a level loaded already
     if (PLAYER_ENTITY) {
-        resetLevelState();
+        resetState();
     }
 
     GAME_STATE->mode = MODE_IN_LEVEL;
@@ -198,19 +202,19 @@ void LevelLoad(char *levelName) {
     if (levelName[0] == '\0') {
         EditorEmpty();
         CameraPanningReset();
-        LEVEL_STATE->awaitingAssociation = true;
+        STATE->awaitingAssociation = true;
         TraceLog(LOG_INFO, "Level waiting for file drop.");
         return;
     }
 
     if (!PersistenceLevelLoad(levelName)) {
-        leaveLevel();
+        leave();
         return;
     }
 
-    LEVEL_STATE->checkpointsLeft = STARTING_CHECKPOINTS_NUMBER;
+    STATE->checkpointsLeft = STARTING_CHECKPOINTS_NUMBER;
 
-    strcpy(LEVEL_STATE->levelName, levelName);
+    strcpy(STATE->levelName, levelName);
 
     EditorSync();
 
@@ -218,48 +222,48 @@ void LevelLoad(char *levelName) {
 
     CameraFollow();
 
-    RenderLevelTransitionEffectStart(
+    Render::LevelTransitionEffectStart(
         SpritePosMiddlePoint(
             {PLAYER_ENTITY->hitbox.x, PLAYER_ENTITY->hitbox.y}, PLAYER_ENTITY->sprite), false);
 
     TraceLog(LOG_INFO, "Level loaded: %s.", levelName);
 }
 
-void LevelGoToOverworld() {
+void GoToOverworld() {
 
     if (!PLAYER_ENTITY) {
-        leaveLevel();
+        leave();
         return;    
     }
 
-    if (LEVEL_STATE->concludedAgo != -1) return;
+    if (STATE->concludedAgo != -1) return;
 
     CameraPanningReset();
 
-    RenderLevelTransitionEffectStart(
+    Render::LevelTransitionEffectStart(
         SpritePosMiddlePoint(
             {PLAYER_ENTITY->hitbox.x, PLAYER_ENTITY->hitbox.y}, PLAYER_ENTITY->sprite), true);
 
     DebugEntityStopAll();
 
-    LEVEL_STATE->concludedAgo = GetTime();
+    STATE->concludedAgo = GetTime();
 }
 
-LevelEntity *LevelCheckpointAdd(Vector2 pos) {
+Entity *CheckpointAdd(Vector2 pos) {
 
-    LevelEntity *newCheckpoint = (LevelEntity *) MemAlloc(sizeof(LevelEntity));
+    Entity *newCheckpoint = new Entity();
 
     Sprite sprite = SPRITES->LevelCheckpoint;
     Rectangle hitbox = SpriteHitboxFromEdge(sprite, pos);
 
-    newCheckpoint->components = LEVEL_IS_CHECKPOINT;
+    newCheckpoint->tags = IS_CHECKPOINT;
     newCheckpoint->hitbox = hitbox;
     newCheckpoint->origin = pos;
     newCheckpoint->sprite = sprite;
     newCheckpoint->isFacingRight = true;
     newCheckpoint->layer = -1;
 
-    LinkedListAdd(&LEVEL_STATE->listHead, newCheckpoint);
+    LinkedList::Add(&STATE->listHead, newCheckpoint);
 
     TraceLog(LOG_TRACE, "Added checkpoint to level (x=%.1f, y=%.1f)",
                 newCheckpoint->hitbox.x, newCheckpoint->hitbox.y);
@@ -267,49 +271,49 @@ LevelEntity *LevelCheckpointAdd(Vector2 pos) {
     return newCheckpoint;
 }
 
-void LevelExitAdd(Vector2 pos) {
+void ExitAdd(Vector2 pos) {
 
-    LevelEntity *newExit = (LevelEntity *) MemAlloc(sizeof(LevelEntity));
+    Entity *newExit = new Entity();
 
     Sprite sprite = SPRITES->LevelEndOrb;
     Rectangle hitbox = SpriteHitboxFromEdge(sprite, pos);
 
-    newExit->components = LEVEL_IS_EXIT;
+    newExit->tags = IS_EXIT;
     newExit->hitbox = hitbox;
     newExit->origin = pos;
     newExit->sprite = sprite;
     newExit->isFacingRight = true;
 
-    LEVEL_STATE->exitNode = LinkedListAdd(&LEVEL_STATE->listHead, newExit);
+    STATE->exitNode = LinkedList::Add(&STATE->listHead, newExit);
 
     TraceLog(LOG_TRACE, "Added exit to level (x=%.1f, y=%.1f)",
                 newExit->hitbox.x, newExit->hitbox.y);
 }
 
-void LevelExitCheckAndAdd(Vector2 pos) {
+void ExitCheckAndAdd(Vector2 pos) {
     
     Rectangle hitbox = SpriteHitboxFromMiddle(SPRITES->LevelEndOrb, pos);
 
-    if (LevelCheckCollisionWithAnything(hitbox)) {
+    if (CheckCollisionWithAnything(hitbox)) {
         TraceLog(LOG_DEBUG, "Couldn't add level exit, collision with entity.");
         return;
     }
 
     // Currently only one level exit is supported, but this should change in the future.
-    if (LEVEL_STATE->exitNode)
-        LinkedListDestroyNode(&LEVEL_STATE->listHead, LEVEL_STATE->exitNode);
+    if (STATE->exitNode)
+        LinkedList::DestroyNode(&STATE->listHead, STATE->exitNode);
     
-    LevelExitAdd({ hitbox.x, hitbox.y });
+    ExitAdd({ hitbox.x, hitbox.y });
 }
 
-void LevelTextboxAdd(Vector2 pos, int textId) {
+void TextboxAdd(Vector2 pos, int textId) {
 
-    LevelEntity *newTextbox = (LevelEntity *) MemAlloc(sizeof(LevelEntity));
+    Entity *newTextbox = new Entity();
 
     Sprite sprite = SPRITES->TextboxButton;
     Rectangle hitbox = SpriteHitboxFromEdge(sprite, pos);
 
-    newTextbox->components = LEVEL_IS_TEXTBOX;
+    newTextbox->tags = IS_TEXTBOX;
     newTextbox->hitbox = hitbox;
     newTextbox->origin = pos;
     newTextbox->sprite = sprite;
@@ -317,17 +321,17 @@ void LevelTextboxAdd(Vector2 pos, int textId) {
     newTextbox->isFacingRight = true;
     newTextbox->textId = textId;
 
-    LinkedListAdd(&LEVEL_STATE->listHead, newTextbox);
+    LinkedList::Add(&STATE->listHead, newTextbox);
 
     TraceLog(LOG_TRACE, "Added textbox button to level (x=%.1f, y=%.1f)",
                 newTextbox->hitbox.x, newTextbox->hitbox.y);
 }
 
-void LevelTextboxCheckAndAdd(Vector2 pos) {
+void TextboxCheckAndAdd(Vector2 pos) {
 
     Rectangle hitbox = SpriteHitboxFromMiddle(SPRITES->TextboxButton, pos);
 
-    if (LevelCheckCollisionWithAnything(hitbox)) {
+    if (CheckCollisionWithAnything(hitbox)) {
         TraceLog(LOG_DEBUG, "Couldn't add textbox button, collision with entity.");
         return;
     }
@@ -339,57 +343,57 @@ void LevelTextboxCheckAndAdd(Vector2 pos) {
         }
     );
 
-    RenderPrintSysMessage("Insira o ID do texto");
+    Render::PrintSysMessage("Insira o ID do texto");
     Input::GetTextInput(callback);
 }
 
-LevelEntity *LevelGetGroundBeneath(LevelEntity *entity) {
+Entity *GetGroundBeneath(Entity *entity) {
 
     return getGroundBeneath(entity->hitbox, entity);    
 }
 
-LevelEntity *LevelGetGroundBeneathHitbox(Rectangle hitbox) {
+Entity *GetGroundBeneathHitbox(Rectangle hitbox) {
 
     return getGroundBeneath(hitbox, 0);
 }
 
-void LevelEntityDestroy(ListNode *node) {
+void EntityDestroy(LinkedList::ListNode *node) {
 
-    if (node == LEVEL_STATE->exitNode) LEVEL_STATE->exitNode = 0;
+    if (node == STATE->exitNode) STATE->exitNode = 0;
 
-    LevelEntity *entity = (LevelEntity *) node->item;
+    Entity *entity = (Entity *) node->item;
 
-    if (entity == LEVEL_STATE->checkpoint) LEVEL_STATE->checkpoint = 0;
+    if (entity == STATE->checkpoint) STATE->checkpoint = 0;
 
     DebugEntityStop(entity);
 
-    LinkedListDestroyNode(&LEVEL_STATE->listHead, node);
+    LinkedList::DestroyNode(&STATE->listHead, node);
 
     TraceLog(LOG_TRACE, "Destroyed level entity.");
 }
 
-LevelEntity *LevelEntityGetAt(Vector2 pos) {
+Entity *EntityGetAt(Vector2 pos) {
 
-    ListNode *node = getEntityNodeAtPos(pos);
+    LinkedList::ListNode *node = getEntityNodeAtPos(pos);
 
     if (!node) return 0;
 
-    return (LevelEntity *) node->item;
+    return (Entity *) node->item;
 }
 
-void LevelEntityRemoveAt(Vector2 pos) {
+void EntityRemoveAt(Vector2 pos) {
 
     // TODO This function is too big and should be broken up
     // in at least two others ASAP
 
-    ListNode *node = LEVEL_STATE->listHead;
+    LinkedList::ListNode *node = STATE->listHead;
     while (node != 0) {
 
-        LevelEntity *entity = (LevelEntity *) node->item;
+        Entity *entity = (Entity *) node->item;
 
-        if (entity->components & LEVEL_IS_PLAYER) goto next_node;
+        if (entity->tags & IS_PLAYER) goto next_node;
 
-        if (CheckCollisionPointRec(pos, LevelEntityOriginHitbox(entity))) {
+        if (CheckCollisionPointRec(pos, EntityOriginHitbox(entity))) {
             break;
         }
 
@@ -403,21 +407,21 @@ next_node:
 
     if (!node) return;
 
-    LevelEntity *entity = (LevelEntity *) node->item;
+    Entity *entity = (Entity *) node->item;
 
-    bool isPartOfSelection = LinkedListGetNode(EDITOR_STATE->selectedEntities, entity);
+    bool isPartOfSelection = LinkedList::GetNode(EDITOR_STATE->selectedEntities, entity);
     if (isPartOfSelection) {
 
-        ListNode *selectedNode = EDITOR_STATE->selectedEntities;
+        LinkedList::ListNode *selectedNode = EDITOR_STATE->selectedEntities;
         while (selectedNode) {
 
-            ListNode *next = selectedNode->next;
-            LevelEntity *selectedEntity = (LevelEntity *) selectedNode->item;
+            LinkedList::ListNode *next = selectedNode->next;
+            Entity *selectedEntity = (Entity *) selectedNode->item;
 
-            if (selectedEntity->components & LEVEL_IS_PLAYER) goto next_selected_node;
+            if (selectedEntity->tags & IS_PLAYER) goto next_selected_node;
 
-            LevelEntityDestroy(
-                LinkedListGetNode(LEVEL_STATE->listHead, selectedEntity));
+            EntityDestroy(
+                LinkedList::GetNode(STATE->listHead, selectedEntity));
 
 next_selected_node:
             selectedNode = next;
@@ -427,54 +431,54 @@ next_selected_node:
 
     } else {
 
-        LevelEntityDestroy(node);
+        EntityDestroy(node);
     }
 }
 
-void LevelPauseToggle() {
+void PauseToggle() {
 
-    if (LEVEL_STATE->isPaused) {
+    if (STATE->isPaused) {
 
         if (PLAYER_ENTITY && PLAYER_ENTITY->isDead) {
             PlayerContinue();
         }
 
-        LEVEL_STATE->isPaused = false;
+        STATE->isPaused = false;
 
     } else {
-        LEVEL_STATE->isPaused = true;
+        STATE->isPaused = true;
     }
 }
 
-void LevelTick() {
+void Tick() {
 
     if (GAME_STATE->waitingForTextInput) return;
 
     // TODO check if having the first check before saves on processing,
     // of if it's just redundant. 
-    if (LEVEL_STATE->concludedAgo != -1 &&
-        GetTime() - LEVEL_STATE->concludedAgo > LEVEL_TRANSITION_ANIMATION_DURATION) {
+    if (STATE->concludedAgo != -1 &&
+        GetTime() - STATE->concludedAgo > LEVEL_TRANSITION_ANIMATION_DURATION) {
 
-        leaveLevel();
+        leave();
 
-        LEVEL_STATE->concludedAgo = -1;
+        STATE->concludedAgo = -1;
 
         return;
     }
 
-    if (!LEVEL_STATE->isPaused && !EDITOR_STATE->isEnabled)
+    if (!STATE->isPaused && !EDITOR_STATE->isEnabled)
         tickAllEntities();
 
     CameraTick();
 }
 
-bool LevelCheckCollisionWithAnyEntity(Rectangle hitbox) {
+bool CheckCollisionWithAnyEntity(Rectangle hitbox) {
 
-    ListNode *node = LEVEL_STATE->listHead;
+    LinkedList::ListNode *node = STATE->listHead;
 
     while (node != 0) {
     
-        LevelEntity *entity = (LevelEntity *) node->item;
+        Entity *entity = (Entity *) node->item;
 
         if (!(entity->isDead) && CheckCollisionRecs(hitbox, entity->hitbox)) {
 
@@ -488,18 +492,18 @@ bool LevelCheckCollisionWithAnyEntity(Rectangle hitbox) {
     return false;
 }
 
-bool LevelCheckCollisionWithAnything(Rectangle hitbox) {
+bool CheckCollisionWithAnything(Rectangle hitbox) {
 
-    return LevelCheckCollisionWithAnythingElse(hitbox, 0);
+    return CheckCollisionWithAnythingElse(hitbox, 0);
 }
 
-bool LevelCheckCollisionWithAnythingElse(Rectangle hitbox, ListNode *entityListHead) {
+bool CheckCollisionWithAnythingElse(Rectangle hitbox, LinkedList::ListNode *entityListHead) {
 
-    ListNode *node = LEVEL_STATE->listHead;
+    LinkedList::ListNode *node = STATE->listHead;
 
     while (node != 0) {
     
-        LevelEntity *entity = (LevelEntity *) node->item;
+        Entity *entity = (Entity *) node->item;
 
         Rectangle entitysOrigin = {
                                         entity->origin.x,       entity->origin.y,
@@ -509,7 +513,7 @@ bool LevelCheckCollisionWithAnythingElse(Rectangle hitbox, ListNode *entityListH
         if (CheckCollisionRecs(hitbox, entitysOrigin) ||
             (!(entity->isDead) && CheckCollisionRecs(hitbox, entity->hitbox))) {
 
-            ListNode *excludedNode = entityListHead;
+            LinkedList::ListNode *excludedNode = entityListHead;
             while (excludedNode != 0) {
                 if (excludedNode->item == entity) goto next_node;
                 excludedNode = excludedNode->next;
@@ -526,25 +530,38 @@ next_node:
     return false;
 }
 
-void LevelSave() {
-    PersistenceLevelSave(LEVEL_STATE->levelName);
+void Save() {
+    PersistenceLevelSave(STATE->levelName);
 }
 
-void LevelLoadNew() {
+void LoadNew() {
 
-    LevelLoad((char *) LEVEL_BLUEPRINT_NAME);
+    Load((char *) LEVEL_BLUEPRINT_NAME);
 
     PLAYER_ENTITY->origin = PLAYERS_ORIGIN;
     PLAYER_ENTITY->hitbox.x = PLAYER_ENTITY->origin.x;
     PLAYER_ENTITY->hitbox.y = PLAYER_ENTITY->origin.y;
 
-    strcpy(LEVEL_STATE->levelName, NEW_LEVEL_NAME);
+    strcpy(STATE->levelName, NEW_LEVEL_NAME);
 }
 
-Rectangle LevelEntityOriginHitbox(LevelEntity *entity) {
+Rectangle EntityOriginHitbox(Entity *entity) {
 
     return {
         entity->origin.x, entity->origin.y,
         entity->hitbox.width, entity->hitbox.height
     };
 }
+
+
+void Entity::Draw() {            
+
+    if (!(tags & IS_ENEMY) || !isDead)
+        Render::DrawLevelEntity(this);
+
+    if (EDITOR_STATE->isEnabled)
+        Render::DrawLevelEntityOrigin(this);
+}
+
+
+} // namespace

--- a/src/level/level.hpp
+++ b/src/level/level.hpp
@@ -38,6 +38,7 @@ typedef enum {
     IS_TEXTBOX      = 256,
 } EntityTag;
 
+
 class Entity : public LinkedList::Node, public Render::IDrawable {
 
 public:
@@ -59,6 +60,7 @@ public:
     void Draw();
 };
 
+
 typedef struct LevelState {
 
     // The head of the linked list of all the level entities
@@ -77,7 +79,7 @@ typedef struct LevelState {
     double concludedAgo;
 
     // Reference to the level exit in the level entity's list
-    LinkedList::Node *exitNode;
+    Entity *exit;
 
     // Reference to the current checkpoint in the level entity's list
     Entity *checkpoint;
@@ -125,7 +127,7 @@ Entity *GetGroundBeneath(Entity *entity);
 Entity *GetGroundBeneathHitbox(Rectangle hitbox);
 
 // Destroys a Entity
-void EntityDestroy(LinkedList::Node *node);
+void EntityDestroy(Entity *entity);
 
 // Searches for level entity in position
 Entity *EntityGetAt(Vector2 pos);

--- a/src/level/level.hpp
+++ b/src/level/level.hpp
@@ -4,6 +4,7 @@
 
 #include <raylib.h>
 #include <string>
+#include <vector>
 
 #include "../linked_list.hpp"
 #include "../assets.hpp"
@@ -37,7 +38,7 @@ typedef enum {
     IS_TEXTBOX      = 256,
 } EntityTag;
 
-class Entity : public LinkedList::NodeItem, public Render::IDrawable {
+class Entity : public LinkedList::Node, public Render::IDrawable {
 
 public:
     unsigned long int tags;
@@ -61,7 +62,7 @@ public:
 typedef struct LevelState {
 
     // The head of the linked list of all the level entities
-    LinkedList::ListNode *listHead;
+    LinkedList::Node *listHead;
 
     // The current loaded level's name
     char levelName[LEVEL_NAME_BUFFER_SIZE];
@@ -76,7 +77,7 @@ typedef struct LevelState {
     double concludedAgo;
 
     // Reference to the level exit in the level entity's list
-    LinkedList::ListNode *exitNode;
+    LinkedList::Node *exitNode;
 
     // Reference to the current checkpoint in the level entity's list
     Entity *checkpoint;
@@ -124,7 +125,7 @@ Entity *GetGroundBeneath(Entity *entity);
 Entity *GetGroundBeneathHitbox(Rectangle hitbox);
 
 // Destroys a Entity
-void EntityDestroy(LinkedList::ListNode *node);
+void EntityDestroy(LinkedList::Node *node);
 
 // Searches for level entity in position
 Entity *EntityGetAt(Vector2 pos);
@@ -157,8 +158,8 @@ bool CheckCollisionWithAnyEntity(Rectangle hitbox);
 bool CheckCollisionWithAnything(Rectangle hitbox);
 
 // Checks for collision between a rectangle and any living entity in the level,
-// including their origins, as long as it's NOT present in a given entity list.
-bool CheckCollisionWithAnythingElse(Rectangle hitbox, LinkedList::ListNode *entityListHead);
+// including their origins, as long as it's NOT present in a given entity vector.
+bool CheckCollisionWithAnythingElse(Rectangle hitbox, std::vector<LinkedList::Node *> entitiesToIgnore);
 
 
 } // namespace

--- a/src/level/level.hpp
+++ b/src/level/level.hpp
@@ -9,6 +9,7 @@
 #include "../assets.hpp"
 #include "../core.hpp"
 #include "../persistence.hpp"
+#include "../render.hpp"
 
 
 // The level used as a basis for new levels
@@ -21,22 +22,25 @@
 #define FLOOR_DEATH_HEIGHT      800
 
 
-// TODO rename from 'component' to 'tag'
-typedef enum LevelEntityComponent {
-    LEVEL_IS_PLAYER         = 1,
-    LEVEL_IS_ENEMY          = 2,
-    LEVEL_IS_SCENARIO       = 4, // the meaning of this component isnt clear
-    LEVEL_IS_EXIT           = 8,
-    LEVEL_IS_GROUND         = 16,
-    LEVEL_IS_DANGER         = 32,
-    LEVEL_IS_GLIDE          = 64,
-    LEVEL_IS_CHECKPOINT     = 128,
-    LEVEL_IS_TEXTBOX        = 256,
-} LevelEntityComponent;
+namespace Level {
 
-typedef struct LevelEntity {
 
-    unsigned long int components;
+typedef enum {
+    IS_PLAYER       = 1,
+    IS_ENEMY        = 2,
+    IS_SCENARIO     = 4, // the meaning of this component isnt clear
+    IS_EXIT         = 8,
+    IS_GROUND       = 16,
+    IS_DANGER       = 32,
+    IS_GLIDE        = 64,
+    IS_CHECKPOINT   = 128,
+    IS_TEXTBOX      = 256,
+} EntityTag;
+
+class Entity : public LinkedList::NodeItem, public Render::IDrawable {
+
+public:
+    unsigned long int tags;
     Vector2 origin;
     Rectangle hitbox;
 
@@ -50,13 +54,14 @@ typedef struct LevelEntity {
 
     // Used by Textbox Buttons
     int textId;
-    
-} LevelEntity;
+
+    void Draw();
+};
 
 typedef struct LevelState {
 
     // The head of the linked list of all the level entities
-    ListNode *listHead;
+    LinkedList::ListNode *listHead;
 
     // The current loaded level's name
     char levelName[LEVEL_NAME_BUFFER_SIZE];
@@ -71,10 +76,10 @@ typedef struct LevelState {
     double concludedAgo;
 
     // Reference to the level exit in the level entity's list
-    ListNode *exitNode;
+    LinkedList::ListNode *exitNode;
 
     // Reference to the current checkpoint in the level entity's list
-    LevelEntity *checkpoint;
+    Entity *checkpoint;
 
     // How many checkpoints the player has left
     int checkpointsLeft;
@@ -82,78 +87,81 @@ typedef struct LevelState {
 } LevelState;
 
 
-extern LevelState *LEVEL_STATE;
+extern LevelState *STATE;
 
 
 // Initialize the level system
-void LevelInitialize();
+void Initialize();
 
 // Loads and goes to the given level
-void LevelLoad(char *levelName);
+void Load(char *levelName);
 
 // Starts "go to Overworld" routine
-void LevelGoToOverworld();
+void GoToOverworld();
+
+// Adds a level checkpoint in the given position
+Entity *CheckpointAdd(Vector2 pos);
 
 // Initializes and adds an exit to the level
-void LevelExitAdd(Vector2 pos);
+void ExitAdd(Vector2 pos);
 
 // Initializes and adds an exit to the level in the given origin,
 // if there are no other entities there already
-void LevelExitCheckAndAdd(Vector2 pos);
+void ExitCheckAndAdd(Vector2 pos);
 
 // Initializes and adds a textbox button to the level
-void LevelTextboxAdd(Vector2 pos, int textId);
+void TextboxAdd(Vector2 pos, int textId);
 
 // Initializes and adds a a textbox button to the level in the
 // given origin, if there are no other entities there already
-void LevelTextboxCheckAndAdd(Vector2 pos);
+void TextboxCheckAndAdd(Vector2 pos);
 
 // The ground beneath the entity, or 0 if not on the ground.
 // Gives priority to the tile in the direction the player is looking at.
-LevelEntity *LevelGetGroundBeneath(LevelEntity *entity);
+Entity *GetGroundBeneath(Entity *entity);
 
 // The ground beneath a hitbox, or 0 if not on the ground.
-LevelEntity *LevelGetGroundBeneathHitbox(Rectangle hitbox);
+Entity *GetGroundBeneathHitbox(Rectangle hitbox);
 
-// Destroys a LevelEntity
-void LevelEntityDestroy(ListNode *node);
+// Destroys a Entity
+void EntityDestroy(LinkedList::ListNode *node);
 
 // Searches for level entity in position
-LevelEntity *LevelEntityGetAt(Vector2 pos);
+Entity *EntityGetAt(Vector2 pos);
 
 // Removes level entity in position from the
 // list and destroys it, if found and if allowed.
-void LevelEntityRemoveAt(Vector2 pos);
+void EntityRemoveAt(Vector2 pos);
 
 // Toggles between paused and unpaused game
-void LevelPauseToggle();
+void PauseToggle();
 
 // Runs the update routine of the level's entities
-void LevelTick();
+void Tick();
 
 // Saves to file the current loaded level's data
-void LevelSave();
+void Save();
 
 // Loads a new, default level
-void LevelLoadNew();
+void LoadNew();
 
 // Get this entity's origin hitbox, based on the current hitbox.
-Rectangle LevelEntityOriginHitbox(LevelEntity *entity);
+Rectangle EntityOriginHitbox(Entity *entity);
 
 // Checks for collision between a rectangle and any 
 // living entity in the level.
-bool LevelCheckCollisionWithAnyEntity(Rectangle hitbox);
+bool CheckCollisionWithAnyEntity(Rectangle hitbox);
 
 // Checks for collision between a rectangle and any 
 // living entity in the level, including their origins.
-bool LevelCheckCollisionWithAnything(Rectangle hitbox);
+bool CheckCollisionWithAnything(Rectangle hitbox);
 
 // Checks for collision between a rectangle and any living entity in the level,
 // including their origins, as long as it's NOT present in a given entity list.
-bool LevelCheckCollisionWithAnythingElse(Rectangle hitbox, ListNode *entityListHead);
+bool CheckCollisionWithAnythingElse(Rectangle hitbox, LinkedList::ListNode *entityListHead);
 
-// Adds a level checkpoint in the given position
-LevelEntity *LevelCheckpointAdd(Vector2 pos);
+
+} // namespace
 
 
 #endif // _LEVEL_H_INCLUDED_

--- a/src/level/player.cpp
+++ b/src/level/player.cpp
@@ -309,11 +309,9 @@ END_HORIZONTAL_VELOCITY_CALCULATION:
             return;
         }
 
-        LinkedList::Node *node = Level::STATE->listHead;
+        Level::Entity *entity = (Level::Entity *) Level::STATE->listHead;
 
-        while (node != 0) {
-
-            Level::Entity *entity = (Level::Entity *) node;
+        while (entity != 0) {
 
             if ((entity->tags & Level::IS_ENEMY) && !entity->isDead) {
 
@@ -417,7 +415,7 @@ END_HORIZONTAL_VELOCITY_CALCULATION:
             }
 
 next_entity:
-            node = node->next;
+            entity = (Level::Entity *)  entity->next;
         }
     }
 
@@ -466,15 +464,14 @@ void PlayerContinue() {
     Level::STATE->isPaused = false;
 
     // Reset all the entities to their origins
-    LinkedList::Node *node = Level::STATE->listHead;
-    while (node) {
+    Level::Entity *entity = (Level::Entity *) Level::STATE->listHead;
+    while (entity) {
 
-        Level::Entity *entity = (Level::Entity *) node;
         entity->isDead = false;
         entity->hitbox.x = entity->origin.x;
         entity->hitbox.y = entity->origin.y;
 
-        node = node->next;
+        entity = (Level::Entity *) entity->next;
     }
 
     if (Level::STATE->checkpoint) {

--- a/src/level/player.cpp
+++ b/src/level/player.cpp
@@ -128,7 +128,7 @@ void PlayerInitialize(Vector2 origin) {
 
     Level::Entity *newPlayer = new Level::Entity();
     PLAYER_ENTITY = newPlayer;
-    LinkedList::Add(&Level::STATE->listHead, newPlayer);
+    LinkedList::AddNode(&Level::STATE->listHead, newPlayer);
  
     newPlayer->tags = Level::IS_PLAYER;
     newPlayer->origin = origin;
@@ -309,11 +309,11 @@ END_HORIZONTAL_VELOCITY_CALCULATION:
             return;
         }
 
-        LinkedList::ListNode *node = Level::STATE->listHead;
+        LinkedList::Node *node = Level::STATE->listHead;
 
         while (node != 0) {
 
-            Level::Entity *entity = (Level::Entity *) node->item;
+            Level::Entity *entity = (Level::Entity *) node;
 
             if ((entity->tags & Level::IS_ENEMY) && !entity->isDead) {
 
@@ -466,10 +466,10 @@ void PlayerContinue() {
     Level::STATE->isPaused = false;
 
     // Reset all the entities to their origins
-    LinkedList::ListNode *node = Level::STATE->listHead;
+    LinkedList::Node *node = Level::STATE->listHead;
     while (node) {
 
-        Level::Entity *entity = (Level::Entity *) node->item;
+        Level::Entity *entity = (Level::Entity *) node;
         entity->isDead = false;
         entity->hitbox.x = entity->origin.x;
         entity->hitbox.y = entity->origin.y;
@@ -509,8 +509,7 @@ void PlayerSetCheckpoint() {
     }
 
     if (Level::STATE->checkpoint) {
-        Level::EntityDestroy(
-            LinkedList::GetNode(Level::STATE->listHead, Level::STATE->checkpoint));
+        Level::EntityDestroy(Level::STATE->checkpoint);
     }
 
     Vector2 pos = RectangleGetPos(PLAYER_ENTITY->hitbox);

--- a/src/level/player.hpp
+++ b/src/level/player.hpp
@@ -15,7 +15,7 @@ typedef enum PlayerMode {
 typedef struct PlayerState {
 
     // The ground beneath the player, updated every frame, or 0 if there's no ground beneath
-    LevelEntity *groundBeneath;
+    Level::Entity *groundBeneath;
 
     // TODO maybe add multiple hitboxes support for every entity
     Rectangle upperbody, lowerbody;
@@ -41,8 +41,8 @@ typedef struct PlayerState {
 } PlayerState;
 
 
-// Reference to the player's LevelEntity, part of the level entity list
-extern LevelEntity *PLAYER_ENTITY; 
+// Reference to the player's Level::Entity, part of the level entity list
+extern Level::Entity *PLAYER_ENTITY; 
 
 extern PlayerState *PLAYER_STATE;
 

--- a/src/level/powerups.cpp
+++ b/src/level/powerups.cpp
@@ -13,7 +13,7 @@ void GlideAdd(Vector2 origin) {
     glide->sprite = SPRITES->GlideItem;
     glide->hitbox = SpriteHitboxFromEdge(glide->sprite, glide->origin);
 
-    LinkedList::Add(&Level::STATE->listHead, glide);
+    LinkedList::AddNode(&Level::STATE->listHead, glide);
 
     TraceLog(LOG_TRACE, "Added glide item to level (x=%.1f, y=%.1f)",
                 glide->hitbox.x, glide->hitbox.y);

--- a/src/level/powerups.cpp
+++ b/src/level/powerups.cpp
@@ -6,14 +6,14 @@
 
 void GlideAdd(Vector2 origin) {
     
-    LevelEntity *glide = (LevelEntity *) MemAlloc(sizeof(LevelEntity));
+    Level::Entity *glide = new Level::Entity();
 
-    glide->components = LEVEL_IS_GLIDE;
+    glide->tags = Level::IS_GLIDE;
     glide->origin = origin;
     glide->sprite = SPRITES->GlideItem;
     glide->hitbox = SpriteHitboxFromEdge(glide->sprite, glide->origin);
 
-    LinkedListAdd(&LEVEL_STATE->listHead, glide);
+    LinkedList::Add(&Level::STATE->listHead, glide);
 
     TraceLog(LOG_TRACE, "Added glide item to level (x=%.1f, y=%.1f)",
                 glide->hitbox.x, glide->hitbox.y);
@@ -24,9 +24,9 @@ void GlideCheckAndAdd(Vector2 origin) {
     origin = SnapToGrid(origin, LEVEL_GRID);
 
     Rectangle hitbox = SpriteHitboxFromEdge(SPRITES->GlideItem, origin);
-    if (LevelCheckCollisionWithAnything(hitbox)) return;
+    if (Level::CheckCollisionWithAnything(hitbox)) return;
 
-    if (!LevelGetGroundBeneathHitbox(hitbox)) {
+    if (!Level::GetGroundBeneathHitbox(hitbox)) {
         TraceLog(LOG_DEBUG, "Didn't add glide item to level, no ground beneath");
         return;
     }

--- a/src/linked_list.cpp
+++ b/src/linked_list.cpp
@@ -6,13 +6,9 @@
 namespace LinkedList {
 
 
-ListNode *Add(ListNode **head, NodeItem *item) {
+Node *AddNode(Node **head, Node *node) {
 
-    ListNode *node = (ListNode *) MemAlloc(sizeof(ListNode));
-
-    node->item = item;
-
-    ListNode *lastItem = *head;
+    Node *lastItem = *head;
 
     if (*head) {
 
@@ -34,15 +30,15 @@ ListNode *Add(ListNode **head, NodeItem *item) {
     return node;
 }
 
-void DestroyNode(ListNode **head, ListNode *node) {
+void DestroyNode(Node **head, Node *node) {
 
-    delete node->item;
     RemoveNode(head, node);
+    delete node;
 
     TraceLog(LOG_TRACE, "Destroyed node with item from linked list.");
 }
 
-void RemoveNode(ListNode **head, ListNode *node) {
+void RemoveNode(Node **head, Node *node) {
 
     if (*head == node) {
         *head = node->next;
@@ -50,35 +46,24 @@ void RemoveNode(ListNode **head, ListNode *node) {
 
     if (node->next) node->next->previous = node->previous;
     if (node->previous) node->previous->next = node->next;
-    MemFree(node);
 
-    TraceLog(LOG_TRACE, "Destroyed node from linked list.");
+    TraceLog(LOG_TRACE, "Removed node from linked list.");
 }
 
-ListNode *GetNode(ListNode *head, void *item) {
-
-    while (head != 0 && head->item != item) {
-        head = head->next;
-    }
-
-    return head;
-}
-
-void DestroyAll(ListNode **head) {
+void DestroyAll(Node **head) {
 
     while (*head) {
         DestroyNode(head, *head);
     }
 
-    TraceLog(LOG_TRACE, "Destroyed a linked list.");
+    TraceLog(LOG_TRACE, "Destroyed all items from a linked list.");
 }
 
-void RemoveAll(ListNode **head) {
+void RemoveAll(Node **head) {
 
-    ListNode *node = *head;
+    Node *node = *head;
     while (node) {
-        ListNode *next = node->next;
-        MemFree(node);
+        Node *next = node->next;
         node = next;
     }
 
@@ -87,9 +72,9 @@ void RemoveAll(ListNode **head) {
     TraceLog(LOG_TRACE, "Removed all items from a linked list.");
 }
 
-int CountNodes(ListNode *head) {
+int CountNodes(Node *head) {
 
-    ListNode *node = head;
+    Node *node = head;
     int counter = 0;
 
     while (node != 0) {

--- a/src/linked_list.cpp
+++ b/src/linked_list.cpp
@@ -35,7 +35,7 @@ void DestroyNode(Node **head, Node *node) {
     RemoveNode(head, node);
     delete node;
 
-    TraceLog(LOG_TRACE, "Destroyed node with item from linked list.");
+    TraceLog(LOG_TRACE, "Destroyed node from linked list.");
 }
 
 void RemoveNode(Node **head, Node *node) {
@@ -56,7 +56,7 @@ void DestroyAll(Node **head) {
         DestroyNode(head, *head);
     }
 
-    TraceLog(LOG_TRACE, "Destroyed all items from a linked list.");
+    TraceLog(LOG_TRACE, "Destroyed all nodes from a linked list.");
 }
 
 void RemoveAll(Node **head) {
@@ -69,7 +69,7 @@ void RemoveAll(Node **head) {
 
     *head = 0;
 
-    TraceLog(LOG_TRACE, "Removed all items from a linked list.");
+    TraceLog(LOG_TRACE, "Removed all nodes from a linked list.");
 }
 
 int CountNodes(Node *head) {

--- a/src/linked_list.cpp
+++ b/src/linked_list.cpp
@@ -3,7 +3,10 @@
 #include "linked_list.hpp"
 
 
-ListNode *LinkedListAdd(ListNode **head, void *item) {
+namespace LinkedList {
+
+
+ListNode *Add(ListNode **head, NodeItem *item) {
 
     ListNode *node = (ListNode *) MemAlloc(sizeof(ListNode));
 
@@ -31,15 +34,15 @@ ListNode *LinkedListAdd(ListNode **head, void *item) {
     return node;
 }
 
-void LinkedListDestroyNode(ListNode **head, ListNode *node) {
+void DestroyNode(ListNode **head, ListNode *node) {
 
-    MemFree(node->item);
-    LinkedListRemoveNode(head, node);
+    delete node->item;
+    RemoveNode(head, node);
 
     TraceLog(LOG_TRACE, "Destroyed node with item from linked list.");
 }
 
-void LinkedListRemoveNode(ListNode **head, ListNode *node) {
+void RemoveNode(ListNode **head, ListNode *node) {
 
     if (*head == node) {
         *head = node->next;
@@ -52,7 +55,7 @@ void LinkedListRemoveNode(ListNode **head, ListNode *node) {
     TraceLog(LOG_TRACE, "Destroyed node from linked list.");
 }
 
-ListNode *LinkedListGetNode(ListNode *head, void *item) {
+ListNode *GetNode(ListNode *head, void *item) {
 
     while (head != 0 && head->item != item) {
         head = head->next;
@@ -61,16 +64,16 @@ ListNode *LinkedListGetNode(ListNode *head, void *item) {
     return head;
 }
 
-void LinkedListDestroyAll(ListNode **head) {
+void DestroyAll(ListNode **head) {
 
     while (*head) {
-        LinkedListDestroyNode(head, *head);
+        DestroyNode(head, *head);
     }
 
     TraceLog(LOG_TRACE, "Destroyed a linked list.");
 }
 
-void LinkedListRemoveAll(ListNode **head) {
+void RemoveAll(ListNode **head) {
 
     ListNode *node = *head;
     while (node) {
@@ -84,7 +87,7 @@ void LinkedListRemoveAll(ListNode **head) {
     TraceLog(LOG_TRACE, "Removed all items from a linked list.");
 }
 
-int LinkedListCountNodes(ListNode *head) {
+int CountNodes(ListNode *head) {
 
     ListNode *node = head;
     int counter = 0;
@@ -96,3 +99,6 @@ int LinkedListCountNodes(ListNode *head) {
 
     return counter;
 }
+
+
+} // namespace

--- a/src/linked_list.hpp
+++ b/src/linked_list.hpp
@@ -2,34 +2,46 @@
 #define _LINKED_LIST_H_INCLUDED_
 
 
+namespace LinkedList {
+
+
+class NodeItem {
+
+public:
+    virtual ~NodeItem() = default; // so objects from derived classes can be deleted from a NodeItem reference
+};
+
 typedef struct ListNode {
     struct ListNode *next;
     struct ListNode *previous;
 
-    void *item;
+    NodeItem *item;
 } ListNode;
 
 
 // Adds new node containing 'item' to a linked list. Returns the new node.
-ListNode *LinkedListAdd(ListNode **head, void *item);
+ListNode *Add(ListNode **head, NodeItem *item);
 
 // Returns list node containing item, or 0 if not found.
-ListNode *LinkedListGetNode(ListNode *head, void *item);
+ListNode *GetNode(ListNode *head, void *item);
 
 // Removes and destroys node, with its item, from a linked list.
-void LinkedListDestroyNode(ListNode **head, ListNode *node);
+void DestroyNode(ListNode **head, ListNode *node);
 
 // Removes and destroys all nodes, with its items, from a linked list.
-void LinkedListDestroyAll(ListNode **head);
+void DestroyAll(ListNode **head);
 
 // Removes and destroys a node from a linked list, but doesn't destroy its item.
-void LinkedListRemoveNode(ListNode **head, ListNode *node);
+void RemoveNode(ListNode **head, ListNode *node);
 
 // Removes all nodes from a linked list, but doesn't destroy the items.
-void LinkedListRemoveAll(ListNode **head);
+void RemoveAll(ListNode **head);
 
 // Counts how many nodes there are in a linked list.
-int LinkedListCountNodes(ListNode *head);
+int CountNodes(ListNode *head);
+
+
+} // namespace
 
 
 #endif // _LINKED_LIST_H_INCLUDED_

--- a/src/linked_list.hpp
+++ b/src/linked_list.hpp
@@ -5,40 +5,33 @@
 namespace LinkedList {
 
 
-class NodeItem {
+class Node {
 
 public:
-    virtual ~NodeItem() = default; // so objects from derived classes can be deleted from a NodeItem reference
+    Node *next;
+    Node *previous;
+
+    virtual ~Node() = default; // so objects from derived classes can be deleted from a Node reference
 };
-
-typedef struct ListNode {
-    struct ListNode *next;
-    struct ListNode *previous;
-
-    NodeItem *item;
-} ListNode;
 
 
 // Adds new node containing 'item' to a linked list. Returns the new node.
-ListNode *Add(ListNode **head, NodeItem *item);
+Node *AddNode(Node **head, Node *node);
 
-// Returns list node containing item, or 0 if not found.
-ListNode *GetNode(ListNode *head, void *item);
+// Removes Node from a linked list and destroys it.
+void DestroyNode(Node **head, Node *node);
 
-// Removes and destroys node, with its item, from a linked list.
-void DestroyNode(ListNode **head, ListNode *node);
+// Removes all Nodes from a linked list and destroys them.
+void DestroyAll(Node **head);
 
-// Removes and destroys all nodes, with its items, from a linked list.
-void DestroyAll(ListNode **head);
+// Removes Node from a linked list, but doesn't destroy it.
+void RemoveNode(Node **head, Node *node);
 
-// Removes and destroys a node from a linked list, but doesn't destroy its item.
-void RemoveNode(ListNode **head, ListNode *node);
-
-// Removes all nodes from a linked list, but doesn't destroy the items.
-void RemoveAll(ListNode **head);
+// Removes all Nodes from a linked list, but doesn't destroy them.
+void RemoveAll(Node **head);
 
 // Counts how many nodes there are in a linked list.
-int CountNodes(ListNode *head);
+int CountNodes(Node *head);
 
 
 } // namespace

--- a/src/linked_list.hpp
+++ b/src/linked_list.hpp
@@ -11,7 +11,7 @@ public:
     Node *next;
     Node *previous;
 
-    virtual ~Node() = default; // so objects from derived classes can be deleted from a Node reference
+    virtual ~Node() = default; // so objects from derived classes can be deleted from a Node pointer
 };
 
 

--- a/src/overworld.hpp
+++ b/src/overworld.hpp
@@ -27,16 +27,17 @@ typedef enum OverworldTileType {
     OW_PATH_IN_L
 } OverworldTileType;
 
-typedef enum OverworldEntityComponent {
+typedef enum OverworldEntityTag {
     OW_IS_CURSOR            = 1,
     OW_IS_LEVEL_DOT         = 2,
     OW_IS_PATH              = 4,
     OW_IS_ROTATABLE         = 8,
-} OverworldEntityComponent;
+} OverworldEntityTag;
 
-typedef struct OverworldEntity {
+class OverworldEntity : public LinkedList::NodeItem {
 
-    unsigned long int components;
+public:
+    unsigned long int tags;
     OverworldTileType tileType;
     
     Vector2 gridPos;
@@ -45,12 +46,12 @@ typedef struct OverworldEntity {
     
     char *levelName;
 
-} OverworldEntity;
+};
 
 typedef struct OverworldState {
 
     // The head of the linked list of all the overworld entities
-    ListNode *listHead;
+    LinkedList::ListNode *listHead;
 
     // Reference to the tile the cursor is over, part of the overworld entity list 
     OverworldEntity *tileUnderCursor;
@@ -92,7 +93,7 @@ OverworldEntity *OverworldCheckCollisionWithAnyTile(Rectangle hitbox);
 
 // Checks for collision between a hitbox and any tile in the overworld
 // that's NOT present in a given list. Returns the collided entity, or 0 if none.
-OverworldEntity *OverworldCheckCollisionWithAnyTileExcept(Rectangle hitbox, ListNode *entityListHead);
+OverworldEntity *OverworldCheckCollisionWithAnyTileExcept(Rectangle hitbox, LinkedList::ListNode *entityListHead);
 
 void OverworldTick();
 

--- a/src/overworld.hpp
+++ b/src/overworld.hpp
@@ -1,6 +1,7 @@
 #ifndef _OVERWORLD_H_INCLUDED_
 #define _OVERWORLD_H_INCLUDED_
 
+#include <vector>
 
 #include "assets.hpp"
 #include "linked_list.hpp"
@@ -34,7 +35,7 @@ typedef enum OverworldEntityTag {
     OW_IS_ROTATABLE         = 8,
 } OverworldEntityTag;
 
-class OverworldEntity : public LinkedList::NodeItem {
+class OverworldEntity : public LinkedList::Node {
 
 public:
     unsigned long int tags;
@@ -51,7 +52,7 @@ public:
 typedef struct OverworldState {
 
     // The head of the linked list of all the overworld entities
-    LinkedList::ListNode *listHead;
+    LinkedList::Node *listHead;
 
     // Reference to the tile the cursor is over, part of the overworld entity list 
     OverworldEntity *tileUnderCursor;
@@ -92,8 +93,8 @@ void OverworldTileRemoveAt(Vector2 pos);
 OverworldEntity *OverworldCheckCollisionWithAnyTile(Rectangle hitbox);
 
 // Checks for collision between a hitbox and any tile in the overworld
-// that's NOT present in a given list. Returns the collided entity, or 0 if none.
-OverworldEntity *OverworldCheckCollisionWithAnyTileExcept(Rectangle hitbox, LinkedList::ListNode *entityListHead);
+// that's NOT present in a given vector. Returns the collided entity, or 0 if none.
+OverworldEntity *OverworldCheckCollisionWithAnyTileExcept(Rectangle hitbox, std::vector<LinkedList::Node *> entitiesToIgnore);
 
 void OverworldTick();
 

--- a/src/persistence.cpp
+++ b/src/persistence.cpp
@@ -60,7 +60,7 @@ static void getFilePath(char *pathBuffer, size_t bufferSize, char *fileName) {
 
 void PersistenceLevelSave(char *levelName) {
 
-    size_t levelItemCount = LinkedListCountNodes(LEVEL_STATE->listHead);
+    size_t levelItemCount = LinkedList::CountNodes(Level::STATE->listHead);
     size_t saveItemCount = levelItemCount;
     size_t entitySize = sizeof(PersistenceLevelEntity);
     PersistenceLevelEntity *data = (PersistenceLevelEntity *) MemAlloc(entitySize * saveItemCount);
@@ -68,29 +68,29 @@ void PersistenceLevelSave(char *levelName) {
     TraceLog(LOG_DEBUG, "Saving level %s... (struct size=%d, level item count=%d)",
                         levelName, entitySize, levelItemCount);
 
-    ListNode *node = LEVEL_STATE->listHead;
+    LinkedList::ListNode *node = Level::STATE->listHead;
     for (size_t i = 0; i < saveItemCount; ) {
 
-        LevelEntity *entity = (LevelEntity *) node->item;
+        Level::Entity *entity = (Level::Entity *) node->item;
 
-        if (entity->components & LEVEL_IS_PLAYER)
+        if (entity->tags & Level::IS_PLAYER)
             data[i].entityType = LEVEL_ENTITY_PLAYER;
-        else if (entity->components & LEVEL_IS_ENEMY)
+        else if (entity->tags & Level::IS_ENEMY)
             data[i].entityType = LEVEL_ENTITY_ENEMY;
-        else if (entity->components & LEVEL_IS_SCENARIO && entity->components & LEVEL_IS_DANGER)
+        else if (entity->tags & Level::IS_SCENARIO && entity->tags & Level::IS_DANGER)
             data[i].entityType = LEVEL_ENTITY_ACID;
-        else if (entity->components & LEVEL_IS_SCENARIO && !(entity->components & LEVEL_IS_DANGER))
+        else if (entity->tags & Level::IS_SCENARIO && !(entity->tags & Level::IS_DANGER))
             data[i].entityType = LEVEL_ENTITY_BLOCK;
-        else if (entity->components & LEVEL_IS_EXIT)
+        else if (entity->tags & Level::IS_EXIT)
             data[i].entityType = LEVEL_ENTITY_EXIT;
-        else if (entity->components & LEVEL_IS_GLIDE)
+        else if (entity->tags & Level::IS_GLIDE)
             data[i].entityType = LEVEL_ENTITY_GLIDE;
-        else if (entity->components & LEVEL_IS_TEXTBOX) {
+        else if (entity->tags & Level::IS_TEXTBOX) {
             data[i].entityType = LEVEL_ENTITY_TEXTBOX;
             memcpy(&data[i].textId, &entity->textId, sizeof(uint32_t));
         }
         else { 
-            TraceLog(LOG_WARNING, "Unknow entity type found when serializing level, components=%d. Skipping it...");
+            TraceLog(LOG_WARNING, "Unknow entity type found when serializing level, tags=%d. Skipping it...");
             saveItemCount--;
             goto skip_entity; 
         }
@@ -111,10 +111,10 @@ skip_entity:
 
     if (FileSave(levelPath, filedata)) {
         TraceLog(LOG_INFO, "Level saved: %s.", levelName);
-        RenderPrintSysMessage("Fase salva.");
+        Render::PrintSysMessage("Fase salva.");
     } else {
         TraceLog(LOG_ERROR, "Could not save level %s.", levelName);
-        RenderPrintSysMessage("Erro salvando fase.");
+        Render::PrintSysMessage("Erro salvando fase.");
     }
 
     MemFree(data);
@@ -132,7 +132,7 @@ bool PersistenceLevelLoad(char *levelName) {
 
     if (!filedata.itemCount) {
         TraceLog(LOG_ERROR, "Could not load level %s.", levelName);
-        RenderPrintSysMessage("Erro carregando fase.");
+        Render::PrintSysMessage("Erro carregando fase.");
         return false;
     }
 
@@ -158,11 +158,11 @@ bool PersistenceLevelLoad(char *levelName) {
         case LEVEL_ENTITY_ACID:
             AcidAdd(origin); break;
         case LEVEL_ENTITY_EXIT:
-            LevelExitAdd(origin); break;
+            Level::ExitAdd(origin); break;
         case LEVEL_ENTITY_GLIDE:
             GlideAdd(origin); break;
         case LEVEL_ENTITY_TEXTBOX:
-            LevelTextboxAdd(origin, textId); break;
+            Level::TextboxAdd(origin, textId); break;
         default:
             TraceLog(LOG_ERROR, "Unknow entity type found when desserializing level, type=%d.", data[i].entityType); 
         }
@@ -199,14 +199,14 @@ bool PersistenceGetDroppedLevelName(char *nameBuffer) {
         strcmp(GetFileName(fileDir), PERSISTENCE_DIR_NAME) != 0) {
 
             TraceLog(LOG_ERROR, "Dropped file is not on 'levels' directory.");
-            RenderPrintSysMessage("Arquivo não é parte do jogo");
+            Render::PrintSysMessage("Arquivo não é parte do jogo");
             goto return_result;
     }
 
     if (strcmp(GetFileExtension(filePath), LEVEL_FILE_EXTENSION) != 0) {
         TraceLog(LOG_ERROR, "Dropped file extension is not %s. Ignoring it",
                     LEVEL_FILE_EXTENSION);
-        RenderPrintSysMessage("Arquivo não é fase");
+        Render::PrintSysMessage("Arquivo não é fase");
         goto return_result;
     }
 
@@ -215,7 +215,7 @@ bool PersistenceGetDroppedLevelName(char *nameBuffer) {
 
             TraceLog(LOG_ERROR, "Dropped file has invalid level name %s.",
                         fileName);
-            RenderPrintSysMessage("Nome de fase proibido");
+            Render::PrintSysMessage("Nome de fase proibido");
             goto return_result;
     }
 
@@ -229,7 +229,7 @@ return_result:
 
 void PersistenceOverworldSave() {
 
-    size_t owItemCount = LinkedListCountNodes(OW_STATE->listHead);
+    size_t owItemCount = LinkedList::CountNodes(OW_STATE->listHead);
     size_t saveItemCount = owItemCount;
     size_t entitySize = sizeof(PersistenceOverworldEntity);
     PersistenceOverworldEntity *data = (PersistenceOverworldEntity *) MemAlloc(entitySize * saveItemCount);
@@ -237,7 +237,7 @@ void PersistenceOverworldSave() {
     TraceLog(LOG_DEBUG, "Saving overworld... (struct size=%d, level item count=%d)",
                         entitySize, owItemCount);
 
-    ListNode *node = OW_STATE->listHead;
+    LinkedList::ListNode *node = OW_STATE->listHead;
     for (size_t i = 0; i < saveItemCount; ) {
 
         OverworldEntity *entity = (OverworldEntity *) node->item;
@@ -274,10 +274,10 @@ skip_entity:
 
     if (FileSave(filePath, filedata)) {
         TraceLog(LOG_INFO, "Overworld saved.");
-        RenderPrintSysMessage("Mundo salvo.");
+        Render::PrintSysMessage("Mundo salvo.");
     } else {
         TraceLog(LOG_ERROR, "Could not save overworld.");
-        RenderPrintSysMessage("Erro salvando mundo.");
+        Render::PrintSysMessage("Erro salvando mundo.");
     }
 
     MemFree(data);
@@ -295,7 +295,7 @@ bool PersistenceOverworldLoad() {
 
     if (!fileData.itemCount) {
         TraceLog(LOG_ERROR, "Could not overworld.");
-        RenderPrintSysMessage("Erro carregando mundo.");
+        Render::PrintSysMessage("Erro carregando mundo.");
         return false;
     }
 

--- a/src/persistence.cpp
+++ b/src/persistence.cpp
@@ -68,10 +68,8 @@ void PersistenceLevelSave(char *levelName) {
     TraceLog(LOG_DEBUG, "Saving level %s... (struct size=%d, level item count=%d)",
                         levelName, entitySize, levelItemCount);
 
-    LinkedList::Node *node = Level::STATE->listHead;
+    Level::Entity *entity = (Level::Entity *) Level::STATE->listHead;
     for (size_t i = 0; i < saveItemCount; ) {
-
-        Level::Entity *entity = (Level::Entity *) node;
 
         if (entity->tags & Level::IS_PLAYER)
             data[i].entityType = LEVEL_ENTITY_PLAYER;
@@ -101,7 +99,7 @@ void PersistenceLevelSave(char *levelName) {
         i++;
 
 skip_entity:
-        node = node->next;
+        entity = (Level::Entity *) entity->next;
     }
 
     FileData filedata = { data, entitySize, saveItemCount };
@@ -237,10 +235,8 @@ void PersistenceOverworldSave() {
     TraceLog(LOG_DEBUG, "Saving overworld... (struct size=%d, level item count=%d)",
                         entitySize, owItemCount);
 
-    LinkedList::Node *node = OW_STATE->listHead;
+    OverworldEntity *entity = (OverworldEntity *) OW_STATE->listHead;
     for (size_t i = 0; i < saveItemCount; ) {
-
-        OverworldEntity *entity = (OverworldEntity *) node;
 
         // Saves only OW_NOT_TILEs
         if (entity->tileType == OW_NOT_TILE) {
@@ -264,7 +260,7 @@ void PersistenceOverworldSave() {
         i++;
 
 skip_entity:
-        node = node->next;
+        entity = (OverworldEntity *) entity->next;
     }
 
     FileData filedata = { data, entitySize, saveItemCount };

--- a/src/persistence.cpp
+++ b/src/persistence.cpp
@@ -68,10 +68,10 @@ void PersistenceLevelSave(char *levelName) {
     TraceLog(LOG_DEBUG, "Saving level %s... (struct size=%d, level item count=%d)",
                         levelName, entitySize, levelItemCount);
 
-    LinkedList::ListNode *node = Level::STATE->listHead;
+    LinkedList::Node *node = Level::STATE->listHead;
     for (size_t i = 0; i < saveItemCount; ) {
 
-        Level::Entity *entity = (Level::Entity *) node->item;
+        Level::Entity *entity = (Level::Entity *) node;
 
         if (entity->tags & Level::IS_PLAYER)
             data[i].entityType = LEVEL_ENTITY_PLAYER;
@@ -237,10 +237,10 @@ void PersistenceOverworldSave() {
     TraceLog(LOG_DEBUG, "Saving overworld... (struct size=%d, level item count=%d)",
                         entitySize, owItemCount);
 
-    LinkedList::ListNode *node = OW_STATE->listHead;
+    LinkedList::Node *node = OW_STATE->listHead;
     for (size_t i = 0; i < saveItemCount; ) {
 
-        OverworldEntity *entity = (OverworldEntity *) node->item;
+        OverworldEntity *entity = (OverworldEntity *) node;
 
         // Saves only OW_NOT_TILEs
         if (entity->tileType == OW_NOT_TILE) {

--- a/src/render.hpp
+++ b/src/render.hpp
@@ -3,22 +3,36 @@
 
 #include "string"
 
-#include "level/level.hpp"
-
 
 #define SYS_MSG_BUFFER_SIZE 1000
 
 #define LEVEL_TRANSITION_ANIMATION_DURATION 0.7 // in seconds
 
 
-void RenderInitialize();
+namespace Level { class Entity; }
+
+namespace Render {
+
+
+class IDrawable {
+
+public:
+    virtual void Draw() = 0;
+};
+
+
+void Initialize();
 
 void Render();
 
-void RenderResizeWindow(int width, int height);
+void ResizeWindow(int width, int height);
+
+void DrawLevelEntity(Level::Entity *entity);
+
+void DrawLevelEntityOrigin(Level::Entity *entity);
 
 // Prints a system message in the screen
-void RenderPrintSysMessage(const std::string &msg);
+void PrintSysMessage(const std::string &msg);
 
 /*
     Starts the visual effect of transitioning from overworld to level or vice-versa.
@@ -26,12 +40,16 @@ void RenderPrintSysMessage(const std::string &msg);
     sceneFocusPont: The point in the scene at the center of the effect.
     isClose: If the effect will close on the sceneFocusPont, or, if false, if it will open from it.
 */
-void RenderLevelTransitionEffectStart(Vector2 sceneFocusPont, bool isClose);
+void LevelTransitionEffectStart(Vector2 sceneFocusPont, bool isClose);
 
-void RenderDisplayTextbox(int textId);
+void DisplayTextbox(int textId);
 
-void RenderDisplayTextboxStop();
+void DisplayTextboxStop();
 
-int RenderGetTextboxTextId();
+int GetTextboxTextId();
+
+
+} // namespace
+
 
 #endif // _RENDER_H_INCLUDED_

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -27,11 +27,11 @@ void Toggle() {
     STATE.isEnabled = !STATE.isEnabled;
 
     if (STATE.isEnabled) {
-        RenderPrintSysMessage("Som ligado");
+        Render::PrintSysMessage("Som ligado");
         TraceLog(LOG_INFO, "Sound enabled.");
     }
     else {
-        RenderPrintSysMessage("Som desligado");
+        Render::PrintSysMessage("Som desligado");
         TraceLog(LOG_INFO, "Sound disabled.");
     }
 }


### PR DESCRIPTION
So I could implement the grappling hook's draw() routine separately, I decided to make Entity an object. Level Entities are now Classes that implement their own draw().

This led to to LinkedLists' Nodes becoming a virtual Class. Different Classes that want to have its objects link to each other in Lists can inherit the Node Class.

Some Nodes were part of different LinkedLists, though, so these secondary lists are now vectors of references to these Nodes, that are now part of only one Linked List. 

It was added namespaces to Render, Level and LinkedList. 