### PR TITLE
Asset hotreload + Entities' sprites are now pointers

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -71,6 +71,7 @@
         "xlocnum": "cpp",
         "xstddef": "cpp",
         "xtr1common": "cpp",
-        "functional": "cpp"
+        "functional": "cpp",
+        "random": "cpp"
     }
 }

--- a/include/raygui.h
+++ b/include/raygui.h
@@ -2072,7 +2072,7 @@ int GuiToggle(Rectangle bounds, const char *text, bool *active)
 }
 
 // GuiToggle customized to display a sprite
-int GuiToggleSprite(Rectangle bounds, Sprite sprite, Vector2 pos, bool *active)
+int GuiToggleSprite(Rectangle bounds, Sprite *sprite, Vector2 pos, bool *active)
 {
     int result = 0;
     GuiState state = guiState;
@@ -2114,9 +2114,9 @@ int GuiToggleSprite(Rectangle bounds, Sprite sprite, Vector2 pos, bool *active)
     }
 
     // Centralizes the sprite inside the button
-    pos.x += (bounds.width - (sprite.sprite.width * sprite.scale)) / 2;
-    pos.y += (bounds.height - (sprite.sprite.height * sprite.scale)) / 2;
-    DrawTextureEx(sprite.sprite, pos, 0, sprite.scale, WHITE);
+    pos.x += (bounds.width - (sprite->sprite.width * sprite->scale)) / 2;
+    pos.y += (bounds.height - (sprite->sprite.height * sprite->scale)) / 2;
+    DrawTextureEx(sprite->sprite, pos, 0, sprite->scale, WHITE);
 
     if (state == STATE_FOCUSED) GuiTooltip(bounds);
     //--------------------------------------------------------------------

--- a/src/assets.cpp
+++ b/src/assets.cpp
@@ -2,6 +2,7 @@
 #include <string>
 
 #include "assets.hpp"
+#include "render.hpp"
 
 
 struct SoundBank *SOUNDS = 0;
@@ -26,6 +27,35 @@ static inline Sprite doubleSizeSprite(std::string texturePath) {
         2,
         0
     };
+}
+
+static void clearAssets() {
+
+    // TODO this is awful. Assets should exist in a hashmap.
+
+
+    for (Sprite *s = (Sprite *) SPRITES;
+            s < (Sprite *) SPRITES + sizeof(SpriteBank);
+            s += sizeof(Sprite)) {
+
+        UnloadTexture(s->sprite);
+    }
+
+    MemFree(SPRITES);
+
+    TraceLog(LOG_INFO, "Sprites cleared.");
+
+
+    for (Sound *s = (Sound *) SOUNDS;
+            s < (Sound *) SOUNDS + sizeof(SoundBank);
+            s += sizeof(Sound)) {
+                
+        UnloadSound(*s);
+    }
+
+    MemFree(SOUNDS);
+
+    TraceLog(LOG_INFO, "Sounds cleared.");
 }
 
 void AssetsInitialize() {
@@ -87,14 +117,21 @@ void AssetsInitialize() {
     TraceLog(LOG_INFO, "Assets initialized.");
 }
 
-Dimensions SpriteScaledDimensions(Sprite s) {
+void AssetsReinitialize() {
+
+    clearAssets();
+    AssetsInitialize();
+    Render::PrintSysMessage("Assets recarregados");
+}
+
+Dimensions SpriteScaledDimensions(Sprite *s) {
     return {
-        s.sprite.width * s.scale,
-        s.sprite.height * s.scale
+        s->sprite.width * s->scale,
+        s->sprite.height * s->scale
     };
 }
 
-Vector2 SpritePosMiddlePoint(Vector2 pos, Sprite sprite) {
+Vector2 SpritePosMiddlePoint(Vector2 pos, Sprite *sprite) {
     Dimensions dimensions = SpriteScaledDimensions(sprite);
 
     return {
@@ -113,7 +150,7 @@ void SpriteRotate(Sprite *sprite, int degrees) {
     TraceLog(LOG_TRACE, "Rotated sprite in %d degrees. Now it's %d degrees.", degrees, sprite->rotation);
 }
 
-Rectangle SpriteHitboxFromEdge(Sprite sprite, Vector2 origin) {
+Rectangle SpriteHitboxFromEdge(Sprite *sprite, Vector2 origin) {
     Dimensions dimensions = SpriteScaledDimensions(sprite);
     return {
         origin.x,
@@ -123,7 +160,7 @@ Rectangle SpriteHitboxFromEdge(Sprite sprite, Vector2 origin) {
     };
 }
 
-Rectangle SpriteHitboxFromMiddle(Sprite sprite, Vector2 middlePoint) {
+Rectangle SpriteHitboxFromMiddle(Sprite *sprite, Vector2 middlePoint) {
     Dimensions dimensions = SpriteScaledDimensions(sprite);
     return {
         middlePoint.x - (dimensions.width / 2),

--- a/src/assets.cpp
+++ b/src/assets.cpp
@@ -16,16 +16,14 @@ Shader ShaderLevelTransition;
 static inline Sprite normalSizeSprite(std::string texturePath) {
     return {
         LoadTexture(texturePath.c_str()),
-        1,
-        0
+        1
     };
 }
 
 static inline Sprite doubleSizeSprite(std::string texturePath) {
     return {
         LoadTexture(texturePath.c_str()),
-        2,
-        0
+        2
     };
 }
 
@@ -35,23 +33,17 @@ static void unloadAssets() {
     // TODO this is awful. Assets should exist in a hashmap.
 
 
-    for (Sprite *s = (Sprite *) SPRITES;
-            s < (Sprite *) SPRITES + sizeof(SpriteBank);
-            s += sizeof(Sprite)) {
-
-        UnloadTexture(s->sprite);
+    Sprite *sprites = (Sprite *) SPRITES;
+    for (int idx = 0; idx < sizeof(SpriteBank)/sizeof(Sprite); idx++) {
+        UnloadTexture(sprites[idx].sprite);
     }
-
     TraceLog(LOG_INFO, "Sprites unloaded.");
 
 
-    for (Sound *s = (Sound *) SOUNDS;
-            s < (Sound *) SOUNDS + sizeof(SoundBank);
-            s += sizeof(Sound)) {
-                
-        UnloadSound(*s);
+    Sound *sound = (Sound *) SOUNDS;
+    for (int idx = 0; idx < sizeof(SoundBank)/sizeof(Sound); idx++) {
+        UnloadSound(sound[idx]);
     }
-
     TraceLog(LOG_INFO, "Sounds unloaded.");
 
 
@@ -115,7 +107,7 @@ static void loadAssets() {
     */
 
     // ShaderDefault = (Shader) { rlGetShaderIdDefault(), rlGetShaderLocsDefault() };
-    
+
     ShaderLevelTransition = LoadShader(0, "../assets/shaders/level_transition.fs");
     while (!IsShaderReady(ShaderLevelTransition)) {
         TraceLog(LOG_INFO, "Waiting for ShaderLevelTransition...");
@@ -155,16 +147,6 @@ Vector2 SpritePosMiddlePoint(Vector2 pos, Sprite *sprite) {
         pos.x + (dimensions.width / 2),
         pos.y + (dimensions.height / 2),
     };
-}
-
-void SpriteRotate(Sprite *sprite, int degrees) {
-    sprite->rotation += degrees;
-    
-    if (sprite->rotation >= 360 || sprite->rotation < 0) {
-        sprite->rotation %= 360;
-    }
-
-    TraceLog(LOG_TRACE, "Rotated sprite in %d degrees. Now it's %d degrees.", degrees, sprite->rotation);
 }
 
 Rectangle SpriteHitboxFromEdge(Sprite *sprite, Vector2 origin) {

--- a/src/assets.hpp
+++ b/src/assets.hpp
@@ -69,20 +69,22 @@ extern Shader ShaderLevelTransition;
 
 void AssetsInitialize();
 
+void AssetsReinitialize();
+
 // Get a Sprite's dimensions, scaled
-Dimensions SpriteScaledDimensions(Sprite sprite);
+Dimensions SpriteScaledDimensions(Sprite *sprite);
 
 // Get a sprite's middle point given its position
-Vector2 SpritePosMiddlePoint(Vector2 pos, Sprite sprite);
+Vector2 SpritePosMiddlePoint(Vector2 pos, Sprite *sprite);
 
 // Rotates sprite in a number of degrees
 void SpriteRotate(Sprite *sprite, int degrees);
 
 // Returns a hitbox in the shape of sprite.
-Rectangle SpriteHitboxFromEdge(Sprite sprite, Vector2 origin);
+Rectangle SpriteHitboxFromEdge(Sprite *sprite, Vector2 origin);
 
 // Returns a hitbox in the shape of sprite, centered around middlePoint.
-Rectangle SpriteHitboxFromMiddle(Sprite sprite, Vector2 middlePoint);
+Rectangle SpriteHitboxFromMiddle(Sprite *sprite, Vector2 middlePoint);
 
 /*
     Configures the uniforms ShaderLevelTransition will use in each execution.

--- a/src/assets.hpp
+++ b/src/assets.hpp
@@ -10,7 +10,6 @@
 typedef struct Sprite {
     Texture2D sprite;
     float scale;
-    int rotation;
 } Sprite;
 
 struct SpriteBank {
@@ -76,9 +75,6 @@ Dimensions SpriteScaledDimensions(Sprite *sprite);
 
 // Get a sprite's middle point given its position
 Vector2 SpritePosMiddlePoint(Vector2 pos, Sprite *sprite);
-
-// Rotates sprite in a number of degrees
-void SpriteRotate(Sprite *sprite, int degrees);
 
 // Returns a hitbox in the shape of sprite.
 Rectangle SpriteHitboxFromEdge(Sprite *sprite, Vector2 origin);

--- a/src/assets.hpp
+++ b/src/assets.hpp
@@ -69,7 +69,7 @@ extern Shader ShaderLevelTransition;
 
 void AssetsInitialize();
 
-void AssetsReinitialize();
+void AssetsHotReload();
 
 // Get a Sprite's dimensions, scaled
 Dimensions SpriteScaledDimensions(Sprite *sprite);

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -46,7 +46,7 @@ static void editorUseEraser(Vector2 cursorPos) {
 }
 
 static EditorEntityButton *addEntityButton(
-    EditorEntityType type, Sprite sprite, void (*handler)(Vector2), EditorInteractionType interaction) {
+    EditorEntityType type, Sprite *sprite, void (*handler)(Vector2), EditorInteractionType interaction) {
 
         EditorEntityButton *newButton = new EditorEntityButton();
         newButton->type = type;
@@ -73,14 +73,14 @@ EditorControlButton *addControlButton(EditorControlType type, char *label, void 
 
 void loadInLevelEditor() {
 
-    addEntityButton(EDITOR_ENTITY_ERASER, SPRITES->Eraser, &editorUseEraser, EDITOR_INTERACTION_HOLD);
-    addEntityButton(EDITOR_ENTITY_ENEMY, SPRITES->Enemy, &EnemyCheckAndAdd, EDITOR_INTERACTION_CLICK);
+    addEntityButton(EDITOR_ENTITY_ERASER, &SPRITES->Eraser, &editorUseEraser, EDITOR_INTERACTION_HOLD);
+    addEntityButton(EDITOR_ENTITY_ENEMY, &SPRITES->Enemy, &EnemyCheckAndAdd, EDITOR_INTERACTION_CLICK);
     EDITOR_STATE->defaultEntityButton =
-        addEntityButton(EDITOR_ENTITY_BLOCK, SPRITES->Block, &BlockCheckAndAdd, EDITOR_INTERACTION_HOLD);
-    addEntityButton(EDITOR_ENTITY_ACID, SPRITES->Acid, &AcidCheckAndAdd, EDITOR_INTERACTION_HOLD);   
-    addEntityButton(EDITOR_ENTITY_EXIT, SPRITES->LevelEndOrb, &Level::ExitCheckAndAdd, EDITOR_INTERACTION_CLICK);
-    addEntityButton(EDITOR_ENTITY_GLIDE, SPRITES->GlideItem, &GlideCheckAndAdd, EDITOR_INTERACTION_CLICK);
-    addEntityButton(EDITOR_ENTITY_TEXTBOX, SPRITES->TextboxButton, &Level::TextboxCheckAndAdd, EDITOR_INTERACTION_CLICK);
+        addEntityButton(EDITOR_ENTITY_BLOCK, &SPRITES->Block, &BlockCheckAndAdd, EDITOR_INTERACTION_HOLD);
+    addEntityButton(EDITOR_ENTITY_ACID, &SPRITES->Acid, &AcidCheckAndAdd, EDITOR_INTERACTION_HOLD);   
+    addEntityButton(EDITOR_ENTITY_EXIT, &SPRITES->LevelEndOrb, &Level::ExitCheckAndAdd, EDITOR_INTERACTION_CLICK);
+    addEntityButton(EDITOR_ENTITY_GLIDE, &SPRITES->GlideItem, &GlideCheckAndAdd, EDITOR_INTERACTION_CLICK);
+    addEntityButton(EDITOR_ENTITY_TEXTBOX, &SPRITES->TextboxButton, &Level::TextboxCheckAndAdd, EDITOR_INTERACTION_CLICK);
 
     addControlButton(EDITOR_CONTROL_SAVE, (char *) "Salvar fase", &Level::Save);
     addControlButton(EDITOR_CONTROL_NEW_LEVEL, (char *) "Nova fase", &Level::LoadNew);
@@ -90,12 +90,12 @@ void loadInLevelEditor() {
 
 void loadOverworldEditor() {
 
-    addEntityButton(EDITOR_ENTITY_ERASER, SPRITES->Eraser, &editorUseEraser, EDITOR_INTERACTION_HOLD);
+    addEntityButton(EDITOR_ENTITY_ERASER, &SPRITES->Eraser, &editorUseEraser, EDITOR_INTERACTION_HOLD);
     EDITOR_STATE->defaultEntityButton =
-        addEntityButton(EDITOR_ENTITY_LEVEL_DOT, SPRITES->LevelDot, &OverworldTileAddOrInteract, EDITOR_INTERACTION_CLICK);
-    addEntityButton(EDITOR_ENTITY_PATH_JOIN, SPRITES->PathTileJoin, &OverworldTileAddOrInteract, EDITOR_INTERACTION_CLICK);
-    addEntityButton(EDITOR_ENTITY_STRAIGHT, SPRITES->PathTileStraight, &OverworldTileAddOrInteract, EDITOR_INTERACTION_CLICK);
-    addEntityButton(EDITOR_ENTITY_PATH_IN_L, SPRITES->PathTileInL, &OverworldTileAddOrInteract, EDITOR_INTERACTION_CLICK);
+        addEntityButton(EDITOR_ENTITY_LEVEL_DOT, &SPRITES->LevelDot, &OverworldTileAddOrInteract, EDITOR_INTERACTION_CLICK);
+    addEntityButton(EDITOR_ENTITY_PATH_JOIN, &SPRITES->PathTileJoin, &OverworldTileAddOrInteract, EDITOR_INTERACTION_CLICK);
+    addEntityButton(EDITOR_ENTITY_STRAIGHT, &SPRITES->PathTileStraight, &OverworldTileAddOrInteract, EDITOR_INTERACTION_CLICK);
+    addEntityButton(EDITOR_ENTITY_PATH_IN_L, &SPRITES->PathTileInL, &OverworldTileAddOrInteract, EDITOR_INTERACTION_CLICK);
 
     addControlButton(EDITOR_CONTROL_SAVE, (char *) "Salvar mundo", &OverworldSave);
     addControlButton(EDITOR_CONTROL_NEW_LEVEL, (char *) "Nova fase", &Level::LoadNew);

--- a/src/editor.hpp
+++ b/src/editor.hpp
@@ -80,7 +80,7 @@ class EditorEntityButton : public LinkedList::Node {
 
 public:
     EditorEntityType type;
-    Sprite sprite;
+    Sprite *sprite;
     void (*handler)(Vector2); // Receives the click scene pos
     EditorInteractionType interactionType;
 

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -61,7 +61,7 @@ void updateInputStates() {
 
 void handleInLevelInput() {
 
-    if (IsKeyPressed(KEY_F5))
+    if (IsKeyPressed(KEY_F7))
         GAME_STATE->showBackground = !GAME_STATE->showBackground;
 
 
@@ -141,6 +141,7 @@ void handleDevInput() {
     if      (IsKeyPressed(KEY_F1))          { EditorEnabledToggle(); return; }
     if      (IsKeyPressed(KEY_F2))          DebugHudToggle();
     if      (IsKeyPressed(KEY_F3))          GAME_STATE->showDebugGrid = !GAME_STATE->showDebugGrid;
+    if      (IsKeyPressed(KEY_F5))          AssetsReinitialize();
     if      (IsKeyPressed(KEY_F6))          Sounds::Toggle();
 
 

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -141,7 +141,7 @@ void handleDevInput() {
     if      (IsKeyPressed(KEY_F1))          { EditorEnabledToggle(); return; }
     if      (IsKeyPressed(KEY_F2))          DebugHudToggle();
     if      (IsKeyPressed(KEY_F3))          GAME_STATE->showDebugGrid = !GAME_STATE->showDebugGrid;
-    if      (IsKeyPressed(KEY_F5))          AssetsReinitialize();
+    if      (IsKeyPressed(KEY_F5))          AssetsHotReload();
     if      (IsKeyPressed(KEY_F6))          Sounds::Toggle();
 
 

--- a/src/level/block.cpp
+++ b/src/level/block.cpp
@@ -12,7 +12,7 @@ void BlockAdd(Vector2 origin) {
                             Level::IS_GROUND +
                             Level::IS_HOOKABLE;
     newBlock->origin = origin;
-    newBlock->sprite = SPRITES->Block;
+    newBlock->sprite = &SPRITES->Block;
     newBlock->hitbox = SpriteHitboxFromEdge(newBlock->sprite, newBlock->origin);
 
     LinkedList::AddNode(&Level::STATE->listHead, newBlock);
@@ -25,7 +25,7 @@ void BlockCheckAndAdd(Vector2 origin) {
 
     origin = SnapToGrid(origin, LEVEL_GRID);
 
-    Rectangle hitbox = SpriteHitboxFromEdge(SPRITES->Block, origin);
+    Rectangle hitbox = SpriteHitboxFromEdge(&SPRITES->Block, origin);
     if (Level::CheckCollisionWithAnything(hitbox)) return;
     
     BlockAdd(origin);
@@ -40,7 +40,7 @@ void AcidAdd(Vector2 origin) {
                             Level::IS_DANGER +
                             Level::IS_HOOKABLE;
     newBlock->origin = origin;
-    newBlock->sprite = SPRITES->Acid;
+    newBlock->sprite = &SPRITES->Acid;
     newBlock->hitbox = SpriteHitboxFromEdge(newBlock->sprite, newBlock->origin);
 
     LinkedList::AddNode(&Level::STATE->listHead, newBlock);
@@ -53,7 +53,7 @@ void AcidCheckAndAdd(Vector2 origin) {
 
     origin = SnapToGrid(origin, LEVEL_GRID);
 
-    Rectangle hitbox = SpriteHitboxFromEdge(SPRITES->Acid, origin);
+    Rectangle hitbox = SpriteHitboxFromEdge(&SPRITES->Acid, origin);
     if (Level::CheckCollisionWithAnything(hitbox)) return;
     
     AcidAdd(origin);

--- a/src/level/enemy.cpp
+++ b/src/level/enemy.cpp
@@ -17,7 +17,7 @@ void EnemyAdd(Vector2 origin) {
                             Level::IS_GROUND +
                             Level::IS_DANGER;
     newEnemy->origin = origin;
-    newEnemy->sprite = SPRITES->Enemy;
+    newEnemy->sprite = &SPRITES->Enemy;
     newEnemy->hitbox = SpriteHitboxFromEdge(newEnemy->sprite, newEnemy->origin);
     newEnemy->isFacingRight = true;
     newEnemy->isFallingDown = true;
@@ -30,7 +30,7 @@ void EnemyAdd(Vector2 origin) {
 
 void EnemyCheckAndAdd(Vector2 origin) {    
 
-    Rectangle hitbox = SpriteHitboxFromMiddle(SPRITES->Enemy, origin);
+    Rectangle hitbox = SpriteHitboxFromMiddle(&SPRITES->Enemy, origin);
 
     if (Level::CheckCollisionWithAnything(hitbox)) {
         TraceLog(LOG_DEBUG, "Couldn't add enemy to level, collision with entity.");

--- a/src/level/level.cpp
+++ b/src/level/level.cpp
@@ -249,7 +249,7 @@ Entity *CheckpointAdd(Vector2 pos) {
 
     Entity *newCheckpoint = new Entity();
 
-    Sprite sprite = SPRITES->LevelCheckpoint;
+    Sprite *sprite = &SPRITES->LevelCheckpoint;
     Rectangle hitbox = SpriteHitboxFromEdge(sprite, pos);
 
     newCheckpoint->tags = IS_CHECKPOINT;
@@ -271,7 +271,7 @@ void ExitAdd(Vector2 pos) {
 
     Entity *newExit = new Entity();
 
-    Sprite sprite = SPRITES->LevelEndOrb;
+    Sprite *sprite = &SPRITES->LevelEndOrb;
     Rectangle hitbox = SpriteHitboxFromEdge(sprite, pos);
 
     newExit->tags = IS_EXIT;
@@ -288,7 +288,7 @@ void ExitAdd(Vector2 pos) {
 
 void ExitCheckAndAdd(Vector2 pos) {
     
-    Rectangle hitbox = SpriteHitboxFromMiddle(SPRITES->LevelEndOrb, pos);
+    Rectangle hitbox = SpriteHitboxFromMiddle(&SPRITES->LevelEndOrb, pos);
 
     if (CheckCollisionWithAnything(hitbox)) {
         TraceLog(LOG_DEBUG, "Couldn't add level exit, collision with entity.");
@@ -306,7 +306,7 @@ void TextboxAdd(Vector2 pos, int textId) {
 
     Entity *newTextbox = new Entity();
 
-    Sprite sprite = SPRITES->TextboxButton;
+    Sprite *sprite = &SPRITES->TextboxButton;
     Rectangle hitbox = SpriteHitboxFromEdge(sprite, pos);
 
     newTextbox->tags = IS_TEXTBOX;
@@ -325,7 +325,7 @@ void TextboxAdd(Vector2 pos, int textId) {
 
 void TextboxCheckAndAdd(Vector2 pos) {
 
-    Rectangle hitbox = SpriteHitboxFromMiddle(SPRITES->TextboxButton, pos);
+    Rectangle hitbox = SpriteHitboxFromMiddle(&SPRITES->TextboxButton, pos);
 
     if (CheckCollisionWithAnything(hitbox)) {
         TraceLog(LOG_DEBUG, "Couldn't add textbox button, collision with entity.");

--- a/src/level/level.hpp
+++ b/src/level/level.hpp
@@ -48,7 +48,7 @@ public:
     Vector2 origin;
     Rectangle hitbox;
 
-    Sprite sprite; // TODO change to "Sprite *sprite"
+    Sprite *sprite;
     int layer;
 
     bool isDead;

--- a/src/level/player.cpp
+++ b/src/level/player.cpp
@@ -78,7 +78,7 @@ void Player::Initialize(Vector2 origin) {
  
     newPlayer->tags = Level::IS_PLAYER;
     newPlayer->origin = origin;
-    newPlayer->sprite = SPRITES->PlayerDefault;
+    newPlayer->sprite = &SPRITES->PlayerDefault;
     newPlayer->SetHitbox(SpriteHitboxFromEdge(newPlayer->sprite, newPlayer->origin));
     newPlayer->isFacingRight = true;
 
@@ -99,7 +99,7 @@ void Player::CheckAndSetOrigin(Vector2 pos) {
 
     if (!PLAYER) return;
 
-    Rectangle newHitbox = SpriteHitboxFromMiddle(SPRITES->PlayerDefault, pos);
+    Rectangle newHitbox = SpriteHitboxFromMiddle(&SPRITES->PlayerDefault, pos);
     
     if (Level::CheckCollisionWithAnyEntity(newHitbox)) {
         TraceLog(LOG_DEBUG,
@@ -521,7 +521,7 @@ next_entity:
     }
 
 
-    sprite = *animationTick();
+    sprite = animationTick();
 }
 
 void Player::Continue() {

--- a/src/level/powerups.cpp
+++ b/src/level/powerups.cpp
@@ -10,7 +10,7 @@ void GlideAdd(Vector2 origin) {
 
     glide->tags = Level::IS_GLIDE;
     glide->origin = origin;
-    glide->sprite = SPRITES->GlideItem;
+    glide->sprite = &SPRITES->GlideItem;
     glide->hitbox = SpriteHitboxFromEdge(glide->sprite, glide->origin);
 
     LinkedList::AddNode(&Level::STATE->listHead, glide);
@@ -23,7 +23,7 @@ void GlideCheckAndAdd(Vector2 origin) {
 
     origin = SnapToGrid(origin, LEVEL_GRID);
 
-    Rectangle hitbox = SpriteHitboxFromEdge(SPRITES->GlideItem, origin);
+    Rectangle hitbox = SpriteHitboxFromEdge(&SPRITES->GlideItem, origin);
     if (Level::CheckCollisionWithAnything(hitbox)) return;
 
     if (!Level::GetGroundBeneathHitbox(hitbox)) {

--- a/src/overworld.cpp
+++ b/src/overworld.cpp
@@ -119,6 +119,11 @@ void OverworldLoad() {
 
 OverworldEntity *OverworldTileAdd(Vector2 pos, OverworldTileType type, int degrees) {
 
+    if (degrees >= 360 || degrees < 0) {
+        degrees %= 360;
+    }
+
+
     OverworldEntity *newTile = new OverworldEntity();
 
     newTile->tileType = type;
@@ -134,17 +139,17 @@ OverworldEntity *OverworldTileAdd(Vector2 pos, OverworldTileType type, int degre
     case OW_STRAIGHT_PATH:
         newTile->tags = OW_IS_PATH + OW_IS_ROTATABLE;
         newTile->sprite = &SPRITES->PathTileStraight;
-        SpriteRotate(newTile->sprite, degrees);
+        newTile->rotation = degrees;
         break;
     case OW_JOIN_PATH:
         newTile->tags = OW_IS_PATH + OW_IS_ROTATABLE;
         newTile->sprite = &SPRITES->PathTileJoin;
-        SpriteRotate(newTile->sprite, degrees);
+        newTile->rotation = degrees;
         break;
     case OW_PATH_IN_L:
         newTile->tags = OW_IS_PATH + OW_IS_ROTATABLE;
         newTile->sprite = &SPRITES->PathTileInL;
-        SpriteRotate(newTile->sprite, degrees);
+        newTile->rotation = degrees;
         break;
     default:
         TraceLog(LOG_ERROR, "Could not find sprite for overworld tile type %d.", type);
@@ -303,7 +308,9 @@ void OverworldTileAddOrInteract(Vector2 pos) {
         }
 
         // Interacting
-        SpriteRotate(entity->sprite, 90);
+        entity->rotation += 90;
+        if (entity->rotation >= 360) entity->rotation -= 360;
+
         TraceLog(LOG_TRACE, "Rotated tile component=%d, x=%.1f, y=%.1f",
                 entity->tags, entity->gridPos.x, entity->gridPos.y);
         return;

--- a/src/overworld.cpp
+++ b/src/overworld.cpp
@@ -33,7 +33,7 @@ static void initializeOverworldState() {
 // Updates the position for the cursor according to the tile under it
 static void updateCursorPosition() {
 
-    Dimensions cursorDimensions = SpriteScaledDimensions(SPRITES->OverworldCursor);
+    Dimensions cursorDimensions = SpriteScaledDimensions(&SPRITES->OverworldCursor);
 
     OW_CURSOR->gridPos.x = OW_STATE->tileUnderCursor->gridPos.x;
 
@@ -74,7 +74,7 @@ static void initializeCursor() {
     OverworldEntity *newCursor = new OverworldEntity();
 
     newCursor->tags = OW_IS_CURSOR;
-    newCursor->sprite = SPRITES->OverworldCursor;
+    newCursor->sprite = &SPRITES->OverworldCursor;
     newCursor->layer = 1;
 
     LinkedList::AddNode(&OW_STATE->listHead, newCursor);
@@ -129,22 +129,22 @@ OverworldEntity *OverworldTileAdd(Vector2 pos, OverworldTileType type, int degre
     {
     case OW_LEVEL_DOT:
         newTile->tags = OW_IS_LEVEL_DOT;
-        newTile->sprite = SPRITES->LevelDot;
+        newTile->sprite = &SPRITES->LevelDot;
         break;
     case OW_STRAIGHT_PATH:
         newTile->tags = OW_IS_PATH + OW_IS_ROTATABLE;
-        newTile->sprite = SPRITES->PathTileStraight;
-        SpriteRotate(&newTile->sprite, degrees);
+        newTile->sprite = &SPRITES->PathTileStraight;
+        SpriteRotate(newTile->sprite, degrees);
         break;
     case OW_JOIN_PATH:
         newTile->tags = OW_IS_PATH + OW_IS_ROTATABLE;
-        newTile->sprite = SPRITES->PathTileJoin;
-        SpriteRotate(&newTile->sprite, degrees);
+        newTile->sprite = &SPRITES->PathTileJoin;
+        SpriteRotate(newTile->sprite, degrees);
         break;
     case OW_PATH_IN_L:
         newTile->tags = OW_IS_PATH + OW_IS_ROTATABLE;
-        newTile->sprite = SPRITES->PathTileInL;
-        SpriteRotate(&newTile->sprite, degrees);
+        newTile->sprite = &SPRITES->PathTileInL;
+        SpriteRotate(newTile->sprite, degrees);
         break;
     default:
         TraceLog(LOG_ERROR, "Could not find sprite for overworld tile type %d.", type);
@@ -303,7 +303,7 @@ void OverworldTileAddOrInteract(Vector2 pos) {
         }
 
         // Interacting
-        SpriteRotate(&entity->sprite, 90);
+        SpriteRotate(entity->sprite, 90);
         TraceLog(LOG_TRACE, "Rotated tile component=%d, x=%.1f, y=%.1f",
                 entity->tags, entity->gridPos.x, entity->gridPos.y);
         return;

--- a/src/overworld.hpp
+++ b/src/overworld.hpp
@@ -42,7 +42,7 @@ public:
     OverworldTileType tileType;
     
     Vector2 gridPos;
-    Sprite sprite;
+    Sprite *sprite;
     int layer; // currently, only used to put the cursor in front of the tiles
     
     char *levelName;

--- a/src/overworld.hpp
+++ b/src/overworld.hpp
@@ -44,6 +44,7 @@ public:
     Vector2 gridPos;
     Sprite *sprite;
     int layer; // currently, only used to put the cursor in front of the tiles
+    int rotation;
     
     char *levelName;
 

--- a/src/persistence.cpp
+++ b/src/persistence.cpp
@@ -245,7 +245,7 @@ void PersistenceOverworldSave() {
         }
         
         data[i].tileType =          entity->tileType;
-        data[i].rotation =          (int32_t) entity->sprite.rotation;
+        data[i].rotation =          (int32_t) entity->sprite->rotation; // TODO rotation part of the entity
         memcpy(&data[i].posX,       &entity->gridPos.x,         sizeof(uint32_t));
         memcpy(&data[i].posY,       &entity->gridPos.y,         sizeof(uint32_t));
 

--- a/src/persistence.cpp
+++ b/src/persistence.cpp
@@ -245,7 +245,7 @@ void PersistenceOverworldSave() {
         }
         
         data[i].tileType =          entity->tileType;
-        data[i].rotation =          (int32_t) entity->sprite->rotation; // TODO rotation part of the entity
+        data[i].rotation =          (int32_t) entity->rotation;
         memcpy(&data[i].posX,       &entity->gridPos.x,         sizeof(uint32_t));
         memcpy(&data[i].posY,       &entity->gridPos.y,         sizeof(uint32_t));
 

--- a/src/render.cpp
+++ b/src/render.cpp
@@ -80,24 +80,24 @@ void drawSceneRectangle(Rectangle rect, Color color) {
     DrawRectangleRec(screenRect, color);
 }
 
-void drawTexture(Sprite *sprite, Vector2 pos, Color tint, bool flipHorizontally) {
+void drawTexture(Sprite *sprite, Vector2 pos, Color tint, int rotation, bool flipHorizontally) {
 
     Dimensions dimensions = SpriteScaledDimensions(sprite);
 
 
     // Raylib's draw function rotates the sprite around the origin, instead of its middle point.
     // Maybe this should be fixed in a way that works for any angle. 
-    if (sprite->rotation == 90)          pos = { pos.x + dimensions.width, pos.y };
-    else if (sprite->rotation == 180)    pos = { pos.x + dimensions.width,
+    if (rotation == 90)          pos = { pos.x + dimensions.width, pos.y };
+    else if (rotation == 180)    pos = { pos.x + dimensions.width,
                                                             pos.y + dimensions.height };
-    else if (sprite->rotation == 270)    pos = { pos.x, pos.y + dimensions.height };
+    else if (rotation == 270)    pos = { pos.x, pos.y + dimensions.height };
 
 
 
     if (!flipHorizontally) {
         DrawTextureEx(sprite->sprite,
                     pos,
-                    sprite->rotation,
+                    rotation,
                     sprite->scale,
                     tint);    
         
@@ -122,7 +122,7 @@ void drawTexture(Sprite *sprite, Vector2 pos, Color tint, bool flipHorizontally)
                     source,
                     destination,
                     { 0, 0 },
-                    sprite->rotation,
+                    rotation,
                     tint);    
 }
 
@@ -191,7 +191,7 @@ void drawOverworldEntity(OverworldEntity *entity) {
                                         entity->gridPos.x,
                                         entity->gridPos.y });
 
-    drawTexture(entity->sprite, { pos.x, pos.y }, WHITE, false);
+    drawTexture(entity->sprite, { pos.x, pos.y }, WHITE, entity->rotation, false);
 }
 
 // Draws the ghost of an editor's selected entity being moved
@@ -206,7 +206,7 @@ void drawOverworldEntityMoveGhost(OverworldEntity *entity) {
     Color color =  { WHITE.r, WHITE.g, WHITE.b,
                             EDITOR_SELECTION_MOVE_TRANSPARENCY };
 
-    drawTexture(entity->sprite, pos, color, false);
+    drawTexture(entity->sprite, pos, color, entity->rotation, false);
 }
 
 // Draws the ghost of an editor's selected entity being moved
@@ -221,7 +221,7 @@ void drawLevelEntityMoveGhost(Level::Entity *entity) {
     Color color =  { WHITE.r, WHITE.g, WHITE.b,
                             EDITOR_SELECTION_MOVE_TRANSPARENCY };
 
-    drawTexture(entity->sprite, pos, color, !entity->isFacingRight);
+    drawTexture(entity->sprite, pos, color, 0, !entity->isFacingRight);
 }
 
 void drawEntities() {
@@ -636,7 +636,7 @@ void DrawLevelEntity(Level::Entity *entity) {
                                         entity->hitbox.x,
                                         entity->hitbox.y });
 
-    drawTexture(entity->sprite, { pos.x, pos.y }, WHITE, !entity->isFacingRight);
+    drawTexture(entity->sprite, { pos.x, pos.y }, WHITE, 0, !entity->isFacingRight);
 }
 
 void DrawLevelEntityOrigin(Level::Entity *entity) {
@@ -646,7 +646,7 @@ void DrawLevelEntityOrigin(Level::Entity *entity) {
                                         entity->origin.y });
 
     drawTexture(entity->sprite, { pos.x, pos.y },
-                 { WHITE.r, WHITE.g, WHITE.b, 30 }, false);
+                 { WHITE.r, WHITE.g, WHITE.b, 30 }, 0, false);
 }
 
 void PrintSysMessage(const std::string &msg) {

--- a/src/render.cpp
+++ b/src/render.cpp
@@ -80,25 +80,25 @@ void drawSceneRectangle(Rectangle rect, Color color) {
     DrawRectangleRec(screenRect, color);
 }
 
-void drawTexture(Sprite sprite, Vector2 pos, Color tint, bool flipHorizontally) {
+void drawTexture(Sprite *sprite, Vector2 pos, Color tint, bool flipHorizontally) {
 
     Dimensions dimensions = SpriteScaledDimensions(sprite);
 
 
     // Raylib's draw function rotates the sprite around the origin, instead of its middle point.
     // Maybe this should be fixed in a way that works for any angle. 
-    if (sprite.rotation == 90)          pos = { pos.x + dimensions.width, pos.y };
-    else if (sprite.rotation == 180)    pos = { pos.x + dimensions.width,
+    if (sprite->rotation == 90)          pos = { pos.x + dimensions.width, pos.y };
+    else if (sprite->rotation == 180)    pos = { pos.x + dimensions.width,
                                                             pos.y + dimensions.height };
-    else if (sprite.rotation == 270)    pos = { pos.x, pos.y + dimensions.height };
+    else if (sprite->rotation == 270)    pos = { pos.x, pos.y + dimensions.height };
 
 
 
     if (!flipHorizontally) {
-        DrawTextureEx(sprite.sprite,
+        DrawTextureEx(sprite->sprite,
                     pos,
-                    sprite.rotation,
-                    sprite.scale,
+                    sprite->rotation,
+                    sprite->scale,
                     tint);    
         
         return;
@@ -107,8 +107,8 @@ void drawTexture(Sprite sprite, Vector2 pos, Color tint, bool flipHorizontally) 
     Rectangle source = {
         0.0,
         0.0,
-        (float) -sprite.sprite.width,
-        (float) sprite.sprite.height
+        (float) -sprite->sprite.width,
+        (float) sprite->sprite.height
     };
 
     Rectangle destination = {
@@ -118,16 +118,16 @@ void drawTexture(Sprite sprite, Vector2 pos, Color tint, bool flipHorizontally) 
         dimensions.height
     };
 
-    DrawTexturePro(sprite.sprite,
+    DrawTexturePro(sprite->sprite,
                     source,
                     destination,
                     { 0, 0 },
-                    sprite.rotation,
+                    sprite->rotation,
                     tint);    
 }
 
 // Draws sprite in the background, with effects applied.
-void drawSpriteInBackground(Sprite sprite, Vector2 pos, int layer) {
+void drawSpriteInBackground(Sprite *sprite, Vector2 pos, int layer) {
 
     float scale = 1;
     Color tint = { 0xFF, 0xFF, 0xFF, 0xFF };
@@ -158,7 +158,7 @@ void drawSpriteInBackground(Sprite sprite, Vector2 pos, int layer) {
     pos.x = pos.x - (CAMERA->pos.x * parallaxSpeed);
     pos.y = pos.y - (CAMERA->pos.y * parallaxSpeed);
 
-    DrawTextureEx(sprite.sprite, pos, 0, (scale * sprite.scale), tint);
+    DrawTextureEx(sprite->sprite, pos, 0, (scale * sprite->scale), tint);
 }
 
 void drawBackground() {
@@ -180,8 +180,8 @@ void drawBackground() {
         DrawRectangle(0, levelBottomOnScreen.y, SCREEN_WIDTH, SCREEN_HEIGHT, BLACK);
 
         if (!GAME_STATE->showBackground) return; 
-        drawSpriteInBackground(SPRITES->Nightclub,   { 1250, 250 },  -1);
-        drawSpriteInBackground(SPRITES->BGHouse,     { 600, 300 },  -2);
+        drawSpriteInBackground(&SPRITES->Nightclub,   { 1250, 250 },  -1);
+        drawSpriteInBackground(&SPRITES->BGHouse,     { 600, 300 },  -2);
     }
 }
 
@@ -336,7 +336,7 @@ void drawOverworldHud() {
         // Draw level name
 
         Vector2 pos = PosInSceneToScreen({ tile->gridPos.x - 20,
-                            tile->gridPos.y + (tile->sprite.sprite.height * tile->sprite.scale) });
+                            tile->gridPos.y + (tile->sprite->sprite.height * tile->sprite->scale) });
 
         char levelName[LEVEL_NAME_BUFFER_SIZE];
 
@@ -515,7 +515,7 @@ void drawEditorCursor() {
     Vector2 m = GetMousePosition();
     if (!IsInPlayArea(m)) return;
 
-    DrawTexture(b->sprite.sprite, m.x, m.y, getColorTransparency(WHITE, 96));
+    DrawTexture(b->sprite->sprite, m.x, m.y, getColorTransparency(WHITE, 96));
 }
 
 void drawEditor() {


### PR DESCRIPTION
While creating the first real animations of the project, it became clear it would be incredibly useful to have asset hotreload, so here it is.

It involved creating loadAssets() and unloadAssets() routines.

The simplest solution demanded that entities have their Sprite as a pointer, instead of a copy of the values from the asset banks. This is probably bad for performance, but for now it will do.

Functions that do operations on Sprites, like finding its middle point, now receive pointers. This seems needless, confusing and was made out of laziness. Just a great idea overall.

There was also a problem where OverworldEntities kept rotation state on Sprite. The rotation parameter was removed from Sprite (as it was not used anywhere else) and added to OverworldEntity, alongside some sprite rotation functionality.