### PR TITLE
Entity tags refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@ build/
 .idea/
 cmake-build-debug/
 cmake-build-debug-visual-studio/
+todo.txt
 
 levels/new_level.lvl

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -122,7 +122,7 @@ static void updateEntitySelectionList() {
             
             if (entity->tags & Level::IS_PLAYER) goto next_entity;
 
-            bool collisionWithEntity = !entity->isDead && CheckCollisionRecs(selectionHitbox, entity->hitbox);
+            bool collisionWithEntity = !entity->IsADeadEnemy() && CheckCollisionRecs(selectionHitbox, entity->hitbox);
             bool collisionWithGhost = CheckCollisionRecs(selectionHitbox, Level::EntityOriginHitbox(entity));
             if (collisionWithEntity || collisionWithGhost) {
                 

--- a/src/level/block.cpp
+++ b/src/level/block.cpp
@@ -12,7 +12,7 @@ Level::Entity *BlockAdd(Vector2 origin) {
 
     Level::Entity *newBlock = new Level::Entity();
 
-    newBlock->tags = Level::IS_SCENARIO +
+    newBlock->tags = Level::IS_COLLIDE_WALL +
                             Level::IS_GROUND +
                             Level::IS_HOOKABLE;
     newBlock->origin = origin;
@@ -45,9 +45,9 @@ Level::Entity *AcidAdd(Vector2 origin) {
 
     Level::Entity *newBlock = new Level::Entity();
 
-    newBlock->tags = Level::IS_SCENARIO +
+    newBlock->tags = Level::IS_COLLIDE_WALL +
                             Level::IS_GROUND +
-                            Level::IS_DANGER +
+                            Level::IS_COLLIDE_DANGER +
                             Level::IS_HOOKABLE;
     newBlock->origin = origin;
     newBlock->sprite = &SPRITES->Acid;

--- a/src/level/enemy.cpp
+++ b/src/level/enemy.cpp
@@ -19,7 +19,7 @@ Level::Entity *EnemyAdd(Vector2 origin) {
 
     newEnemy->tags = Level::IS_ENEMY +
                             Level::IS_GROUND +
-                            Level::IS_DANGER;
+                            Level::IS_COLLIDE_DANGER;
     newEnemy->origin = origin;
     newEnemy->sprite = &SPRITES->Enemy;
     newEnemy->hitbox = SpriteHitboxFromEdge(newEnemy->sprite, newEnemy->origin);
@@ -102,7 +102,7 @@ void EnemyTick(Level::Entity *enemy) {
 
         if (entity == enemy) goto next_node;
 
-        if (entity->tags & Level::IS_SCENARIO &&
+        if (entity->tags & Level::IS_COLLIDE_WALL &&
             CheckCollisionRecs(entity->hitbox, enemy->hitbox)) {
 
                 enemy->isFacingRight = !enemy->isFacingRight;

--- a/src/level/grappling_hook.cpp
+++ b/src/level/grappling_hook.cpp
@@ -32,7 +32,7 @@ GrapplingHook *GrapplingHook::Initialize() {
 
     GrapplingHook *hook = new GrapplingHook();
 
-    hook->tags = Level::IS_HOOK;
+    hook->tags = 0;
     hook->isFacingRight = PLAYER->isFacingRight;
 
     hook->FollowPlayer();

--- a/src/level/level.cpp
+++ b/src/level/level.cpp
@@ -131,7 +131,7 @@ static Entity *getGroundBeneath(Rectangle hitbox, Entity *entity) {
         if (possibleGround != entity &&
             possibleGround->tags & IS_GROUND &&
 
-            !(possibleGround->isDead) &&
+            !possibleGround->IsADeadEnemy() &&
 
             // If x is within the possible ground
             possibleGround->hitbox.x < (hitbox.x + hitbox.width) &&
@@ -343,7 +343,7 @@ void EntityRemoveAt(Vector2 pos) {
             break;
         }
 
-        if (!(entity->isDead) && CheckCollisionPointRec(pos, entity->hitbox)) {
+        if (!entity->IsADeadEnemy() && CheckCollisionPointRec(pos, entity->hitbox)) {
             break;
         }
 
@@ -416,7 +416,7 @@ bool CheckCollisionWithAnyEntity(Rectangle hitbox) {
 
     while (entity != 0) {
 
-        if (!(entity->isDead) && CheckCollisionRecs(hitbox, entity->hitbox)) {
+        if (!entity->IsADeadEnemy() && CheckCollisionRecs(hitbox, entity->hitbox)) {
             return true;
         }
 
@@ -443,7 +443,7 @@ bool CheckCollisionWithAnythingElse(Rectangle hitbox, std::vector<LinkedList::No
                                     };
 
         if (CheckCollisionRecs(hitbox, entitysOrigin) ||
-            (!(entity->isDead) && CheckCollisionRecs(hitbox, entity->hitbox))) {
+            (!entity->IsADeadEnemy() && CheckCollisionRecs(hitbox, entity->hitbox))) {
 
             for (auto e = entitiesToIgnore.begin(); e < entitiesToIgnore.end(); e++) {
                 if (*e == entity) goto next_entity;
@@ -492,7 +492,7 @@ void Entity::Tick() {
 
 void Entity::Draw() {            
 
-    if (!(tags & IS_ENEMY) || !isDead)
+    if (!(tags & IS_ENEMY) || !isDead) // TODO Enemy class
         Render::DrawLevelEntity(this);
 
     if (EDITOR_STATE->isEnabled)

--- a/src/level/level.cpp
+++ b/src/level/level.cpp
@@ -235,7 +235,7 @@ Entity *CheckpointFlagAdd(Vector2 pos) {
     Sprite *sprite = &SPRITES->LevelCheckpointFlag;
     Rectangle hitbox = SpriteHitboxFromEdge(sprite, pos);
 
-    newCheckpoint->tags = IS_CHECKPOINT;
+    newCheckpoint->tags = 0;
     newCheckpoint->hitbox = hitbox;
     newCheckpoint->origin = pos;
     newCheckpoint->sprite = sprite;

--- a/src/level/level.hpp
+++ b/src/level/level.hpp
@@ -29,14 +29,14 @@ namespace Level {
 typedef enum {
     IS_PLAYER               = 1,
     IS_ENEMY                = 2,
-    IS_SCENARIO             = 4, // the meaning of this component isnt clear
+    IS_COLLIDE_WALL         = 4,
     IS_EXIT                 = 8,
     IS_GROUND               = 16,
-    IS_DANGER               = 32,
-    IS_GLIDE                = 64,
-    IS_CHECKPOINT           = 128,
+    IS_COLLIDE_DANGER       = 32,
+    IS_GLIDE_PICKUP         = 64,
+    //IS_CHECKPOINT           = 128,
     IS_TEXTBOX              = 256,
-    IS_HOOK                 = 512,
+    //IS_HOOK                 = 512,
     IS_HOOKABLE             = 1024,
     IS_CHECKPOINT_PICKUP    = 2048,
 } EntityTag;

--- a/src/level/level.hpp
+++ b/src/level/level.hpp
@@ -64,6 +64,10 @@ public:
     virtual std::string PersistanceSerialize();
     virtual void PersistenceParse(const std::string &data);
 
+    // If the entity's hitbox should be ignored when it's dead.
+    bool IsADeadEnemy() {
+        return (tags & IS_ENEMY) && isDead;
+    }
 };
 
 

--- a/src/level/player.cpp
+++ b/src/level/player.cpp
@@ -436,13 +436,13 @@ COLISION_CHECKING:
                 }
             }
 
-            else if (entity->tags & Level::IS_SCENARIO) {
+            else if (entity->tags & Level::IS_COLLIDE_WALL) {
 
                 // Check for collision with level geometry
 
                 Rectangle collisionRec = GetCollisionRec(entity->hitbox, hitbox);
 
-                if (entity->tags & Level::IS_DANGER &&
+                if (entity->tags & Level::IS_COLLIDE_DANGER &&
                     (collisionRec.width > 0 || collisionRec.height > 0 || groundBeneath == entity)) {
                     
                     // Player hit dangerous level element
@@ -507,7 +507,7 @@ COLISION_CHECKING:
                 Level::GoToOverworld();
             }
 
-            else if (entity->tags & Level::IS_GLIDE &&
+            else if (entity->tags & Level::IS_GLIDE_PICKUP &&
                         CheckCollisionRecs(entity->hitbox, hitbox) &&
                         mode != PLAYER_MODE_GLIDE) {
                 SetMode(PLAYER_MODE_GLIDE);

--- a/src/level/powerups.cpp
+++ b/src/level/powerups.cpp
@@ -12,7 +12,7 @@ Level::Entity *GlideAdd(Vector2 origin) {
     
     Level::Entity *glide = new Level::Entity();
 
-    glide->tags = Level::IS_GLIDE;
+    glide->tags = Level::IS_GLIDE_PICKUP;
     glide->origin = origin;
     glide->sprite = &SPRITES->GlideItem;
     glide->hitbox = SpriteHitboxFromEdge(glide->sprite, glide->origin);

--- a/src/persistence.cpp
+++ b/src/persistence.cpp
@@ -75,13 +75,13 @@ void PersistenceLevelSave(char *levelName) {
             entityTag = LEVEL_ENTITY_PLAYER;
         else if (entity->tags & Level::IS_ENEMY)
             entityTag = LEVEL_ENTITY_ENEMY;
-        else if (entity->tags & Level::IS_SCENARIO && entity->tags & Level::IS_DANGER)
+        else if (entity->tags & Level::IS_COLLIDE_WALL && entity->tags & Level::IS_COLLIDE_DANGER)
             entityTag = LEVEL_ENTITY_ACID;
-        else if (entity->tags & Level::IS_SCENARIO && !(entity->tags & Level::IS_DANGER))
+        else if (entity->tags & Level::IS_COLLIDE_WALL && !(entity->tags & Level::IS_COLLIDE_DANGER))
             entityTag = LEVEL_ENTITY_BLOCK;
         else if (entity->tags & Level::IS_EXIT)
             entityTag = LEVEL_ENTITY_EXIT;
-        else if (entity->tags & Level::IS_GLIDE)
+        else if (entity->tags & Level::IS_GLIDE_PICKUP)
             entityTag = LEVEL_ENTITY_GLIDE;
         else if (entity->tags & Level::IS_CHECKPOINT_PICKUP)
             entityTag = LEVEL_ENITTY_CHECKPOINT_PICKUP;

--- a/src/render.cpp
+++ b/src/render.cpp
@@ -489,7 +489,7 @@ void drawEditorEntitySelection() {
             if (EDITOR_STATE->isMovingSelectedEntities) {
                 drawLevelEntityMoveGhost(entity);
             } else {
-                if (!entity->isDead) drawSceneRectangle(entity->hitbox, color);
+                if (!entity->IsADeadEnemy()) drawSceneRectangle(entity->hitbox, color);
                 drawSceneRectangle(Level::EntityOriginHitbox(entity), color);
             }
 


### PR DESCRIPTION
- IS_SCENARIO became IS_COLLIDE_WALL
- IS_DANGER became IS_COLLIDE_DANGER
- IS_GLIDE became IS_GLIDE_PICKUP
- IS_HOOK and IS_CHECKPOINT were commented out

- Added a IsADeadEnemy() member fuction to the Level Entity. Various interactions related to the editor and to level collision excluded entities that had isDead=true presuming that only Enemies would ever be marked as dead when these interactions happened. This is definitely not a safe assumption -- if any other entity was set as dead by mistake stuff would break.