### PR TITLE
Separated the Level entityTypeID from PersistenceEntityID()

### DIFF
--- a/src/level/block.cpp
+++ b/src/level/block.cpp
@@ -40,7 +40,7 @@ Block *Block::Add(Vector2 origin) {
     newBlock->origin = origin;
     newBlock->TileTypeSet(DEFAULT_TILE_TYPE);
     newBlock->hitbox = SpriteHitboxFromEdge(newBlock->sprite, newBlock->origin);
-
+    newBlock->entityTypeID = BLOCK_ENTITY_ID;
 
     LinkedList::AddNode(&Level::STATE->listHead, newBlock);
 
@@ -227,8 +227,7 @@ AcidBlock *AcidBlock::Add(Vector2 origin) {
     newBlock->origin = origin;
     newBlock->sprite = &SPRITES->Acid;
     newBlock->hitbox = SpriteHitboxFromEdge(newBlock->sprite, newBlock->origin);
-
-    newBlock->persistanceEntityID = ACID_BLOCK_PERSISTENCE_ID;
+    newBlock->entityTypeID = ACID_BLOCK_ENTITY_ID;
 
     LinkedList::AddNode(&Level::STATE->listHead, newBlock);
 

--- a/src/level/block.hpp
+++ b/src/level/block.hpp
@@ -43,7 +43,7 @@ public:
     
     void PersistenceParse(const std::string &data) override;
     
-    std::string PersistanceEntityID() {
+    std::string EntityTypeID() {
         return BLOCK_PERSISTENCE_ID;
     }
     

--- a/src/level/block.hpp
+++ b/src/level/block.hpp
@@ -8,8 +8,8 @@
 #include "level.hpp"
 #include "../assets.hpp"
 
-#define BLOCK_PERSISTENCE_ID        "block"
-#define ACID_BLOCK_PERSISTENCE_ID   "acid_block"
+#define BLOCK_ENTITY_ID        "block"
+#define ACID_BLOCK_ENTITY_ID   "acid_block"
 
 
 class Block : public Level::Entity {
@@ -42,10 +42,6 @@ public:
     std::string PersistanceSerialize() override;
     
     void PersistenceParse(const std::string &data) override;
-    
-    std::string EntityTypeID() {
-        return BLOCK_PERSISTENCE_ID;
-    }
     
 private:
 

--- a/src/level/checkpoint.cpp
+++ b/src/level/checkpoint.cpp
@@ -29,6 +29,7 @@ Level::Entity *CheckpointPickup::Add(Vector2 pos) {
     newPickup->sprite = sprite;
     newPickup->isFacingRight = true;
     newPickup->layer = -1;
+    newPickup->entityTypeID = CHECKPOINT_PICKUP_ENTITY_ID;
 
     newPickup->wasPickedUp = false;
 

--- a/src/level/checkpoint.hpp
+++ b/src/level/checkpoint.hpp
@@ -6,7 +6,7 @@
 #include "level.hpp"
 #include "../animation.hpp"
 
-#define CHECKPOINT_PICKUP_PERSISTENCE_ID        "checkpoint_pickup"
+#define CHECKPOINT_PICKUP_ENTITY_ID        "checkpoint_pickup"
 
 
 class CheckpointPickup : public Level::Entity, private Animation::IAnimated {
@@ -28,10 +28,6 @@ public:
     void Tick();
 
     void Draw();
-
-    std::string EntityTypeID() {
-        return CHECKPOINT_PICKUP_PERSISTENCE_ID;
-    }
 
 private:
 

--- a/src/level/checkpoint.hpp
+++ b/src/level/checkpoint.hpp
@@ -29,7 +29,7 @@ public:
 
     void Draw();
 
-    std::string PersistanceEntityID() {
+    std::string EntityTypeID() {
         return CHECKPOINT_PICKUP_PERSISTENCE_ID;
     }
 

--- a/src/level/enemy.cpp
+++ b/src/level/enemy.cpp
@@ -29,6 +29,7 @@ Enemy *Enemy::Add(Vector2 origin) {
     newEnemy->hitbox = SpriteHitboxFromEdge(newEnemy->sprite, newEnemy->origin);
     newEnemy->isFacingRight = true;
     newEnemy->isFallingDown = true;
+    newEnemy->entityTypeID = ENEMY_ENTITY_ID;
 
     LinkedList::AddNode(&Level::STATE->listHead, newEnemy);
 
@@ -172,6 +173,7 @@ EnemyDummySpike *EnemyDummySpike::Add(Vector2 origin) {
     newEnemy->hitbox = SpriteHitboxFromEdge(newEnemy->sprite, newEnemy->origin);
     newEnemy->isFacingRight = true;
     newEnemy->isFallingDown = true;
+    newEnemy->entityTypeID = ENEMY_DUMMY_ENTITY_ID;
 
     newEnemy->initializeAnimationSystem();
 

--- a/src/level/enemy.hpp
+++ b/src/level/enemy.hpp
@@ -7,8 +7,8 @@
 #include "level.hpp"
 #include "../animation.hpp"
 
-#define ENEMY_PERSISTENCE_ID        "enemy"
-#define ENEMY_DUMMY_PERSISTENCE_ID  "enemy_dummy_spike"
+#define ENEMY_ENTITY_ID        "enemy"
+#define ENEMY_DUMMY_ENTITY_ID  "enemy_dummy_spike"
 
 
 class Enemy : public Level::Entity {
@@ -33,9 +33,6 @@ public:
 
     virtual void Draw();
 
-    std::string EntityTypeID() {
-        return ENEMY_PERSISTENCE_ID;
-    }
 };
 
 
@@ -56,10 +53,6 @@ public:
     void Tick() override;
 
     void Draw() override;
-
-    std::string EntityTypeID() override {
-        return ENEMY_DUMMY_PERSISTENCE_ID;
-    }
 
 private:
 

--- a/src/level/enemy.hpp
+++ b/src/level/enemy.hpp
@@ -33,7 +33,7 @@ public:
 
     virtual void Draw();
 
-    std::string PersistanceEntityID() {
+    std::string EntityTypeID() {
         return ENEMY_PERSISTENCE_ID;
     }
 };
@@ -57,7 +57,7 @@ public:
 
     void Draw() override;
 
-    std::string PersistanceEntityID() override {
+    std::string EntityTypeID() override {
         return ENEMY_DUMMY_PERSISTENCE_ID;
     }
 

--- a/src/level/level.cpp
+++ b/src/level/level.cpp
@@ -259,7 +259,7 @@ Entity *ExitAdd(Vector2 pos) {
     newExit->sprite = sprite;
     newExit->isFacingRight = true;
 
-    newExit->persistanceEntityID = EXIT_PERSISTENCE_ID;
+    newExit->entityTypeID = EXIT_ENTITY_ID;
 
     STATE->exit = (Entity *) LinkedList::AddNode(&STATE->listHead, newExit);
 

--- a/src/level/level.hpp
+++ b/src/level/level.hpp
@@ -22,7 +22,9 @@
 // Below this y entities die
 #define FLOOR_DEATH_HEIGHT      1400
 
-#define EXIT_PERSISTENCE_ID     "lvl_exit"
+#define EXIT_ENTITY_ID     "lvl_exit"
+
+#define UNKNOW_LEVEL_ENTITY_ID  "!!!_unknown_level_entity"
 
 
 namespace Level {
@@ -65,8 +67,9 @@ public:
     bool isFacingRight;
     bool isFallingDown;
 
-    // It's a variable so it supports entity types that simply instantiates Entity (i.e. not a subclass)
-    std::string persistanceEntityID = "!!!_unknown_level_entity";
+    // It's an object attribute so it supports entity types that simply instantiates Entity (i.e. not a subclass).
+    // It would save memory, though, if it was part of the class definition -- like a static method returning a compile-time const.
+    std::string entityTypeID = UNKNOW_LEVEL_ENTITY_ID;
     
 
     // Resets entity to its default state
@@ -97,8 +100,12 @@ public:
     virtual std::string PersistanceSerialize();
     virtual void PersistenceParse(const std::string &data);
 
-    std::string EntityTypeID() {
-        return persistanceEntityID;
+    // Yields the entityTypeID system for the PersistenceEntityID tag.
+    const std::string &PersitenceEntityID() override final {
+        if (entityTypeID == UNKNOW_LEVEL_ENTITY_ID) {
+            TraceLog(LOG_ERROR, "Level entity had its PersitenceEntityID() called, but it has no entityTypeID [tags=%lu]", tags);
+        }
+        return entityTypeID;
     }
 
     // If the entity's hitbox should be ignored when it's dead.

--- a/src/level/level.hpp
+++ b/src/level/level.hpp
@@ -22,7 +22,7 @@
 // Below this y entities die
 #define FLOOR_DEATH_HEIGHT      1400
 
-#define EXIT_ENTITY_ID     "lvl_exit"
+#define EXIT_ENTITY_ID          "lvl_exit"
 
 #define UNKNOW_LEVEL_ENTITY_ID  "!!!_unknown_level_entity"
 

--- a/src/level/level.hpp
+++ b/src/level/level.hpp
@@ -97,7 +97,7 @@ public:
     virtual std::string PersistanceSerialize();
     virtual void PersistenceParse(const std::string &data);
 
-    std::string PersistanceEntityID() {
+    std::string EntityTypeID() {
         return persistanceEntityID;
     }
 

--- a/src/level/moving_platform.cpp
+++ b/src/level/moving_platform.cpp
@@ -91,6 +91,7 @@ MovingPlatform *MovingPlatform::Add(Vector2 startPos, Vector2 endPos, int size) 
     newPlatform->sprite = &SPRITES->MovingPlatform;
     newPlatform->isFacingRight = true;
     newPlatform->layer = -1;
+    newPlatform->entityTypeID = MOVING_PLATFORM_ENTITY_ID;
 
     newPlatform->startAnchor.SetPos(startPos);
     newPlatform->endAnchor.SetPos(endPos);

--- a/src/level/moving_platform.hpp
+++ b/src/level/moving_platform.hpp
@@ -7,7 +7,7 @@
 #include "../camera.hpp"
 
 
-#define MOVING_PLATFORM_PERSISTENCE_ID          "moving_platform"
+#define MOVING_PLATFORM_ENTITY_ID          "moving_platform"
 
 
 class MovingPlatform;
@@ -70,9 +70,6 @@ public:
 
     std::string PersistanceSerialize() override;
     void PersistenceParse(const std::string &data) override;
-    std::string EntityTypeID() {
-        return MOVING_PLATFORM_PERSISTENCE_ID;
-    }
 
 private:
 

--- a/src/level/moving_platform.hpp
+++ b/src/level/moving_platform.hpp
@@ -70,7 +70,7 @@ public:
 
     std::string PersistanceSerialize() override;
     void PersistenceParse(const std::string &data) override;
-    std::string PersistanceEntityID() {
+    std::string EntityTypeID() {
         return MOVING_PLATFORM_PERSISTENCE_ID;
     }
 

--- a/src/level/npc/npc.cpp
+++ b/src/level/npc/npc.cpp
@@ -4,7 +4,7 @@
 #include "../../editor.hpp"
 
 
-#define NPC_TYPE_DEFAULT        PRINCESS_PERSISTENCE_ID
+#define NPC_TYPE_DEFAULT        PRINCESS_ENTITY_ID
 
 #define NPC_FALL_RATE           7.0f
 
@@ -21,7 +21,7 @@ void INpc::Initialize() {
     */
 
     npcTypeMap = {
-        { PRINCESS_PERSISTENCE_ID, &Princess::CheckAndAdd }
+        { PRINCESS_ENTITY_ID, &Princess::CheckAndAdd }
     };
 }
 
@@ -37,7 +37,7 @@ void INpc::CheckAndAdd(Vector2 pos, int interactionTags) {
 
         if (collidedEntity->tags & Level::IS_NPC && interactionTags & EDITOR_INTERACTION_ALT) {
             
-            npcType = ((INpc *)collidedEntity)->EntityTypeID();
+            npcType = collidedEntity->entityTypeID;
             
             Level::EntityDestroy(collidedEntity);
 

--- a/src/level/npc/npc.cpp
+++ b/src/level/npc/npc.cpp
@@ -37,7 +37,7 @@ void INpc::CheckAndAdd(Vector2 pos, int interactionTags) {
 
         if (collidedEntity->tags & Level::IS_NPC && interactionTags & EDITOR_INTERACTION_ALT) {
             
-            npcType = ((INpc *)collidedEntity)->PersistanceEntityID();
+            npcType = ((INpc *)collidedEntity)->EntityTypeID();
             
             Level::EntityDestroy(collidedEntity);
 

--- a/src/level/npc/npc.hpp
+++ b/src/level/npc/npc.hpp
@@ -24,7 +24,8 @@ public:
 
     // TODO should use a more general Entity Type ID instead of relying on PersistanceEntityID
     // for identifying the NPC type
-    virtual std::string PersistanceEntityID() = 0;
+    // TODOEntityTypeID
+    virtual std::string EntityTypeID() = 0;
 
 
 private:

--- a/src/level/npc/npc.hpp
+++ b/src/level/npc/npc.hpp
@@ -22,12 +22,6 @@ public:
 
     virtual void Reset() override;
 
-    // TODO should use a more general Entity Type ID instead of relying on PersistanceEntityID
-    // for identifying the NPC type
-    // TODOEntityTypeID
-    virtual std::string EntityTypeID() = 0;
-
-
 private:
 
     // Defines the different NPC types and which add function to use for each of them

--- a/src/level/npc/princess.cpp
+++ b/src/level/npc/princess.cpp
@@ -20,6 +20,7 @@ Princess *Princess::Add(Vector2 pos) {
     newPrincess->sprite = sprite;
     newPrincess->layer = -1;
     newPrincess->isFacingRight = true;
+    newPrincess->entityTypeID = PRINCESS_ENTITY_ID;
 
     newPrincess->isFalling = true;
 
@@ -37,7 +38,7 @@ void Princess::CheckAndAdd(Vector2 pos) {
 
     if (Level::CheckCollisionWithAnything(hitbox)) {
         Render::PrintSysMessage("Sem espaço para NPC (Princesa)");
-        TraceLog(LOG_DEBUG, "Couldn't add Princess to level, collision with entity.");
+        TraceLog(LOG_TRACE, "Couldn't add Princess to level, collision with entity.");
         return;
     }
 

--- a/src/level/npc/princess.hpp
+++ b/src/level/npc/princess.hpp
@@ -3,7 +3,7 @@
 #include "npc.hpp"
 
 
-#define PRINCESS_PERSISTENCE_ID          "princess"
+#define PRINCESS_ENTITY_ID          "princess"
 
 
 class Princess : public INpc {
@@ -15,8 +15,4 @@ public:
     static Princess *Add(Vector2 pos);
 
     static void CheckAndAdd(Vector2 pos);
-
-    std::string EntityTypeID() {
-        return PRINCESS_PERSISTENCE_ID;
-    }
 };

--- a/src/level/npc/princess.hpp
+++ b/src/level/npc/princess.hpp
@@ -16,7 +16,7 @@ public:
 
     static void CheckAndAdd(Vector2 pos);
 
-    std::string PersistanceEntityID() {
+    std::string EntityTypeID() {
         return PRINCESS_PERSISTENCE_ID;
     }
 };

--- a/src/level/player.cpp
+++ b/src/level/player.cpp
@@ -130,6 +130,8 @@ Player *Player::Initialize(Vector2 origin) {
 
     newPlayer->jumpGlowAnimationCountdown = -1;
 
+    newPlayer->entityTypeID = PLAYER_ENTITY_ID;
+
     newPlayer->initializeAnimationSystem();
 
 

--- a/src/level/player.hpp
+++ b/src/level/player.hpp
@@ -9,7 +9,7 @@
 #include "textbox.hpp"
 #include "../animation.hpp"
 
-#define PLAYER_PERSISTENCE_ID   "player"
+#define PLAYER_ENTITY_ID   "player"
 
 
 typedef enum PlayerMode {
@@ -136,9 +136,6 @@ private:
     
     Animation::Animation *getCurrentAnimation();
 
-    std::string EntityTypeID() {
-        return PLAYER_PERSISTENCE_ID;
-    }
 };
 
 

--- a/src/level/player.hpp
+++ b/src/level/player.hpp
@@ -136,7 +136,7 @@ private:
     
     Animation::Animation *getCurrentAnimation();
 
-    std::string PersistanceEntityID() {
+    std::string EntityTypeID() {
         return PLAYER_PERSISTENCE_ID;
     }
 };

--- a/src/level/powerups.cpp
+++ b/src/level/powerups.cpp
@@ -19,7 +19,7 @@ Level::Entity *GlideAdd(Vector2 origin) {
     glide->sprite = &SPRITES->GlideItem;
     glide->hitbox = SpriteHitboxFromEdge(glide->sprite, glide->origin);
 
-    glide->persistanceEntityID = GLIDE_PICKUP_PERSISTENCE_ID;
+    glide->entityTypeID = GLIDE_PICKUP_ENTITY_ID;
 
     LinkedList::AddNode(&Level::STATE->listHead, glide);
 

--- a/src/level/powerups.hpp
+++ b/src/level/powerups.hpp
@@ -5,7 +5,7 @@
 
 #include "level.hpp"
 
-#define GLIDE_PICKUP_PERSISTENCE_ID         "glide_pickup"
+#define GLIDE_PICKUP_ENTITY_ID         "glide_pickup"
 
 
 Level::Entity *GlideAdd();

--- a/src/level/textbox.cpp
+++ b/src/level/textbox.cpp
@@ -45,6 +45,7 @@ Textbox *Textbox::Add(Vector2 pos, int textId) {
     newTextbox->isFacingRight = true;
     newTextbox->isDevTextbox = false;
     newTextbox->SetTextId(textId);
+    newTextbox->entityTypeID = TEXTBOX_BUTTON_ENTITY_ID;
 
     newTextbox->initializeAnimationSystem();
 

--- a/src/level/textbox.hpp
+++ b/src/level/textbox.hpp
@@ -54,7 +54,7 @@ public:
     void PersistenceParse(const std::string &data) override;
     std::string PersistanceSerialize() override;
 
-    std::string PersistanceEntityID() {
+    std::string EntityTypeID() {
         return TEXTBOX_BUTTON_PERSISTENCE_ID;
     }
 

--- a/src/level/textbox.hpp
+++ b/src/level/textbox.hpp
@@ -8,7 +8,7 @@
 #include "../animation.hpp"
 
 
-#define TEXTBOX_BUTTON_PERSISTENCE_ID       "textbox_button"
+#define TEXTBOX_BUTTON_ENTITY_ID       "textbox_button"
 
 
 class Textbox : public Level::Entity, private Animation::IAnimated {
@@ -53,10 +53,6 @@ public:
 
     void PersistenceParse(const std::string &data) override;
     std::string PersistanceSerialize() override;
-
-    std::string EntityTypeID() {
-        return TEXTBOX_BUTTON_PERSISTENCE_ID;
-    }
 
 private:
 

--- a/src/persistence.cpp
+++ b/src/persistence.cpp
@@ -63,7 +63,7 @@ void PersistenceLevelSave(char *levelName) {
 
             if (!(entity->tags & Level::IS_PERSISTABLE)) continue;
 
-            data += entity->PersistanceEntityID() + ":" + entity->PersistanceSerialize() + '\n';
+            data += entity->EntityTypeID() + ":" + entity->PersistanceSerialize() + '\n';
     }
 
     char *levelPath = (char *) MemAlloc(LEVEL_PATH_BUFFER_SIZE);

--- a/src/persistence.cpp
+++ b/src/persistence.cpp
@@ -63,7 +63,7 @@ void PersistenceLevelSave(char *levelName) {
 
             if (!(entity->tags & Level::IS_PERSISTABLE)) continue;
 
-            data += entity->EntityTypeID() + ":" + entity->PersistanceSerialize() + '\n';
+            data += entity->PersitenceEntityID() + ":" + entity->PersistanceSerialize() + '\n';
     }
 
     char *levelPath = (char *) MemAlloc(LEVEL_PATH_BUFFER_SIZE);
@@ -102,27 +102,27 @@ bool PersistenceLevelLoad(char *levelName) {
             
                                                         // There's gotta be a better way to associate (at compilation
                                                         // or initialization time) a string tag to a function pointer
-            if (entityTag == PLAYER_PERSISTENCE_ID)
+            if (entityTag == PLAYER_ENTITY_ID)
                 entity = Player::Initialize();
-            else if (entityTag == ENEMY_PERSISTENCE_ID)
+            else if (entityTag == ENEMY_ENTITY_ID)
                 entity = Enemy::Add();
-            else if (entityTag == BLOCK_PERSISTENCE_ID)
+            else if (entityTag == BLOCK_ENTITY_ID)
                 entity = Block::Add();
-            else if (entityTag == ACID_BLOCK_PERSISTENCE_ID)
+            else if (entityTag == ACID_BLOCK_ENTITY_ID)
                 entity = AcidBlock::Add();
-            else if (entityTag == EXIT_PERSISTENCE_ID)
+            else if (entityTag == EXIT_ENTITY_ID)
                 entity = Level::ExitAdd();
-            else if (entityTag == GLIDE_PICKUP_PERSISTENCE_ID)
+            else if (entityTag == GLIDE_PICKUP_ENTITY_ID)
                 entity = GlideAdd();
-            else if (entityTag == CHECKPOINT_PICKUP_PERSISTENCE_ID)
+            else if (entityTag == CHECKPOINT_PICKUP_ENTITY_ID)
                 entity = CheckpointPickup::Add();
-            else if (entityTag == TEXTBOX_BUTTON_PERSISTENCE_ID)
+            else if (entityTag == TEXTBOX_BUTTON_ENTITY_ID)
                 entity = Textbox::Add();
-            else if (entityTag == MOVING_PLATFORM_PERSISTENCE_ID)
+            else if (entityTag == MOVING_PLATFORM_ENTITY_ID)
                 entity = MovingPlatform::Add();
-            else if (entityTag == ENEMY_DUMMY_PERSISTENCE_ID)
+            else if (entityTag == ENEMY_DUMMY_ENTITY_ID)
                 entity = EnemyDummySpike::Add();
-            else if (entityTag == PRINCESS_PERSISTENCE_ID)
+            else if (entityTag == PRINCESS_ENTITY_ID)
                 entity = Princess::Add();
             else {
                 TraceLog(LOG_ERROR, "Unknow entity type found when desserializing level, entityTag=%s.", entityTag.c_str());

--- a/src/persistence.hpp
+++ b/src/persistence.hpp
@@ -33,7 +33,7 @@ public:
 
 	// The ID unique to an entity type that can be persisted.
 	// This ID should be associated to the entity's initalization function at PersistenceLevelLoad().
-	virtual std::string EntityTypeID() = 0;
+	virtual const std::string &PersitenceEntityID() = 0;
 
 	/*
 		Adds a value to a data string. To be used inside PersistenceSerialize().

--- a/src/persistence.hpp
+++ b/src/persistence.hpp
@@ -33,7 +33,7 @@ public:
 
 	// The ID unique to an entity type that can be persisted.
 	// This ID should be associated to the entity's initalization function at PersistenceLevelLoad().
-	virtual std::string PersistanceEntityID() = 0;
+	virtual std::string EntityTypeID() = 0;
 
 	/*
 		Adds a value to a data string. To be used inside PersistenceSerialize().


### PR DESCRIPTION
The NPC type identification was relying on PersistenceEntityID. Though this still  won't fix the issue 100%, given that the NPC type identification should have its own system, it seemed like a good opportunity to untie the Level entityTypeID from the PersistenceEntityID() system.

Because some level entities still don't have their own classes, entityTypeID is just an entity's attribute. Given that the entities already had this attribute for the same reason, it won't make matters worse to get rid of each entity class's PeristenceEntityID() override. But once all entity types have their own classes, entityTypeID should turn into a static class with a compile-time constant string, and IPersistable should have a virtual AddFromPersitance() method to get rid of that ugly switch in saveLevel().

Level::Entity automatically turns the entityTypeID into PersistenceEntityID(). Maybe this will become a problem in the future, but it's fine for now.